### PR TITLE
feat: command schemas and registry

### DIFF
--- a/src/client/command.ts
+++ b/src/client/command.ts
@@ -61,7 +61,9 @@ export interface ParsedCommand<
 export function declareCommand<
 	TArgs extends z.ZodTypeAny,
 	TOptions extends z.ZodTypeAny,
->(definition: CommandDefinition<TArgs, TOptions>): CommandSchema<TArgs, TOptions> {
+>(
+	definition: CommandDefinition<TArgs, TOptions>,
+): CommandSchema<TArgs, TOptions> {
 	return Object.freeze({
 		name: definition.name,
 		category: definition.category,
@@ -128,9 +130,14 @@ export function parseCommand(
 
 	// For 'type' command, join remaining positionals as text
 	// (e.g., 'type e3 hello world' → { ref: 'e3', text: 'hello world' })
-	if (entry.positionals.length >= 2 && positionals.length > entry.positionals.length) {
+	if (
+		entry.positionals.length >= 2 &&
+		positionals.length > entry.positionals.length
+	) {
 		const lastPositionalName = entry.positionals[entry.positionals.length - 1];
-		const joinedRemaining = positionals.slice(entry.positionals.length - 1).join(' ');
+		const joinedRemaining = positionals
+			.slice(entry.positionals.length - 1)
+			.join(' ');
 		argsObj[lastPositionalName] = joinedRemaining;
 	}
 

--- a/src/client/commands.ts
+++ b/src/client/commands.ts
@@ -1,9 +1,6 @@
 import { z } from 'zod';
 
-import {
-	declareCommand,
-	type CommandRegistryEntry,
-} from './command.js';
+import { declareCommand, type CommandRegistryEntry } from './command.js';
 
 // ---------------------------------------------------------------------------
 // Core commands
@@ -17,7 +14,10 @@ export const open = declareCommand({
 		url: z.string().optional().describe('URL to open'),
 	}),
 	options: z.object({
-		browser: z.string().optional().describe('Browser to use (e.g., "chrome", "electron")'),
+		browser: z
+			.string()
+			.optional()
+			.describe('Browser to use (e.g., "chrome", "electron")'),
 		headed: z.boolean().optional().describe('Run in headed mode'),
 		config: z.string().optional().describe('Path to Cypress config file'),
 	}),
@@ -45,7 +45,10 @@ export const snapshot = declareCommand({
 	description: 'Get current aria snapshot of the page',
 	args: z.object({}),
 	options: z.object({
-		diff: z.boolean().optional().describe('Return incremental diff from last snapshot'),
+		diff: z
+			.boolean()
+			.optional()
+			.describe('Return incremental diff from last snapshot'),
 	}),
 });
 
@@ -101,7 +104,10 @@ export const click = declareCommand({
 		ref: z.string().describe('Element ref from aria snapshot (e.g., "e5")'),
 	}),
 	options: z.object({
-		force: z.boolean().optional().describe('Force click, disabling actionability checks'),
+		force: z
+			.boolean()
+			.optional()
+			.describe('Force click, disabling actionability checks'),
 		multiple: z.boolean().optional().describe('Click multiple elements'),
 	}),
 });
@@ -114,7 +120,10 @@ export const dblclick = declareCommand({
 		ref: z.string().describe('Element ref from aria snapshot (e.g., "e5")'),
 	}),
 	options: z.object({
-		force: z.boolean().optional().describe('Force double-click, disabling actionability checks'),
+		force: z
+			.boolean()
+			.optional()
+			.describe('Force double-click, disabling actionability checks'),
 	}),
 });
 
@@ -126,7 +135,10 @@ export const rightclick = declareCommand({
 		ref: z.string().describe('Element ref from aria snapshot (e.g., "e5")'),
 	}),
 	options: z.object({
-		force: z.boolean().optional().describe('Force right-click, disabling actionability checks'),
+		force: z
+			.boolean()
+			.optional()
+			.describe('Force right-click, disabling actionability checks'),
 	}),
 });
 
@@ -140,7 +152,10 @@ export const type_ = declareCommand({
 	}),
 	options: z.object({
 		delay: z.number().optional().describe('Delay between keystrokes in ms'),
-		force: z.boolean().optional().describe('Force type, disabling actionability checks'),
+		force: z
+			.boolean()
+			.optional()
+			.describe('Force type, disabling actionability checks'),
 	}),
 });
 
@@ -152,7 +167,10 @@ export const clear = declareCommand({
 		ref: z.string().describe('Element ref from aria snapshot'),
 	}),
 	options: z.object({
-		force: z.boolean().optional().describe('Force clear, disabling actionability checks'),
+		force: z
+			.boolean()
+			.optional()
+			.describe('Force clear, disabling actionability checks'),
 	}),
 });
 
@@ -164,7 +182,10 @@ export const check = declareCommand({
 		ref: z.string().describe('Element ref from aria snapshot'),
 	}),
 	options: z.object({
-		force: z.boolean().optional().describe('Force check, disabling actionability checks'),
+		force: z
+			.boolean()
+			.optional()
+			.describe('Force check, disabling actionability checks'),
 	}),
 });
 
@@ -176,7 +197,10 @@ export const uncheck = declareCommand({
 		ref: z.string().describe('Element ref from aria snapshot'),
 	}),
 	options: z.object({
-		force: z.boolean().optional().describe('Force uncheck, disabling actionability checks'),
+		force: z
+			.boolean()
+			.optional()
+			.describe('Force uncheck, disabling actionability checks'),
 	}),
 });
 
@@ -189,7 +213,10 @@ export const select = declareCommand({
 		value: z.string().describe('Option value or visible text to select'),
 	}),
 	options: z.object({
-		force: z.boolean().optional().describe('Force select, disabling actionability checks'),
+		force: z
+			.boolean()
+			.optional()
+			.describe('Force select, disabling actionability checks'),
 	}),
 });
 
@@ -218,7 +245,9 @@ export const scrollto = declareCommand({
 	category: 'interaction',
 	description: 'Scroll to element or position',
 	args: z.object({
-		target: z.string().describe('Element ref or scroll position (e.g., "top", "bottom")'),
+		target: z
+			.string()
+			.describe('Element ref or scroll position (e.g., "top", "bottom")'),
 	}),
 	options: z.object({
 		duration: z.number().optional().describe('Scroll animation duration in ms'),
@@ -233,7 +262,10 @@ export const hover = declareCommand({
 		ref: z.string().describe('Element ref from aria snapshot'),
 	}),
 	options: z.object({
-		force: z.boolean().optional().describe('Force hover, disabling actionability checks'),
+		force: z
+			.boolean()
+			.optional()
+			.describe('Force hover, disabling actionability checks'),
 	}),
 });
 
@@ -261,7 +293,9 @@ export const assert_ = declareCommand({
 	description: 'Assert on an element',
 	args: z.object({
 		ref: z.string().describe('Element ref from aria snapshot'),
-		chainer: z.string().describe('Chai chainer (e.g., "be.visible", "have.text", "contain")'),
+		chainer: z
+			.string()
+			.describe('Chai chainer (e.g., "be.visible", "have.text", "contain")'),
 		value: z.string().optional().describe('Expected value'),
 	}),
 	options: z.object({}),
@@ -424,9 +458,18 @@ export function buildRegistry(): ReadonlyMap<string, CommandRegistryEntry> {
 	registry.set('press', { schema: press, positionals: ['key'] });
 
 	// Assertion
-	registry.set('assert', { schema: assert_, positionals: ['ref', 'chainer', 'value'] });
-	registry.set('asserturl', { schema: asserturl, positionals: ['chainer', 'value'] });
-	registry.set('asserttitle', { schema: asserttitle, positionals: ['chainer', 'value'] });
+	registry.set('assert', {
+		schema: assert_,
+		positionals: ['ref', 'chainer', 'value'],
+	});
+	registry.set('asserturl', {
+		schema: asserturl,
+		positionals: ['chainer', 'value'],
+	});
+	registry.set('asserttitle', {
+		schema: asserttitle,
+		positionals: ['chainer', 'value'],
+	});
 
 	// Export
 	registry.set('export', { schema: export_, positionals: [] });

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -15,8 +15,4 @@ export {
 	type CommandRegistryEntry,
 } from './command.js';
 
-export {
-	allCommands,
-	buildRegistry,
-	commandRegistry,
-} from './commands.js';
+export { allCommands, buildRegistry, commandRegistry } from './commands.js';

--- a/tests/unit/client/commands.test.ts
+++ b/tests/unit/client/commands.test.ts
@@ -165,10 +165,17 @@ describe('command schemas', () => {
 		});
 
 		it('assert requires ref and chainer, value is optional', () => {
-			const withValue = assert_.args.safeParse({ ref: 'e5', chainer: 'have.text', value: 'Hello' });
+			const withValue = assert_.args.safeParse({
+				ref: 'e5',
+				chainer: 'have.text',
+				value: 'Hello',
+			});
 			expect(withValue.success).toBe(true);
 
-			const withoutValue = assert_.args.safeParse({ ref: 'e5', chainer: 'be.visible' });
+			const withoutValue = assert_.args.safeParse({
+				ref: 'e5',
+				chainer: 'be.visible',
+			});
 			expect(withoutValue.success).toBe(true);
 
 			const missingChainer = assert_.args.safeParse({ ref: 'e5' });
@@ -226,10 +233,7 @@ describe('command schemas', () => {
 
 describe('parseCommand', () => {
 	it("parses 'click e5' correctly", () => {
-		const result = parseCommand(
-			{ _: ['click', 'e5'] },
-			commandRegistry,
-		);
+		const result = parseCommand({ _: ['click', 'e5'] }, commandRegistry);
 		expect(result).toEqual({
 			command: 'click',
 			args: { ref: 'e5' },
@@ -329,7 +333,11 @@ describe('parseCommand', () => {
 		expect(backResult).toEqual({ command: 'back', args: {}, options: {} });
 
 		const forwardResult = parseCommand({ _: ['forward'] }, commandRegistry);
-		expect(forwardResult).toEqual({ command: 'forward', args: {}, options: {} });
+		expect(forwardResult).toEqual({
+			command: 'forward',
+			args: {},
+			options: {},
+		});
 
 		const reloadResult = parseCommand({ _: ['reload'] }, commandRegistry);
 		expect(reloadResult).toEqual({ command: 'reload', args: {}, options: {} });
@@ -348,10 +356,7 @@ describe('parseCommand', () => {
 	});
 
 	it("parses 'press Enter' correctly", () => {
-		const result = parseCommand(
-			{ _: ['press', 'Enter'] },
-			commandRegistry,
-		);
+		const result = parseCommand({ _: ['press', 'Enter'] }, commandRegistry);
 		expect(result).toEqual({
 			command: 'press',
 			args: { key: 'Enter' },
@@ -360,10 +365,7 @@ describe('parseCommand', () => {
 	});
 
 	it("parses 'wait 2000' correctly", () => {
-		const result = parseCommand(
-			{ _: ['wait', '2000'] },
-			commandRegistry,
-		);
+		const result = parseCommand({ _: ['wait', '2000'] }, commandRegistry);
 		expect(result).toEqual({
 			command: 'wait',
 			args: { ms: 2000 },
@@ -432,10 +434,7 @@ describe('parseCommand', () => {
 	});
 
 	it("parses 'hover e3' correctly", () => {
-		const result = parseCommand(
-			{ _: ['hover', 'e3'] },
-			commandRegistry,
-		);
+		const result = parseCommand({ _: ['hover', 'e3'] }, commandRegistry);
 		expect(result).toEqual({
 			command: 'hover',
 			args: { ref: 'e3' },


### PR DESCRIPTION
## What

Implements command schemas and registry for all CLI commands using `declareCommand` + zod schemas.

Closes #5

## Changes

### `src/client/command.ts`
- `declareCommand()` helper that creates frozen, typed command schema objects
- `parseCommand()` function that validates raw minimist-parsed CLI arguments against the command registry
- `CommandValidationError` class for actionable error messages
- Types: `CommandSchema`, `CommandCategory`, `ParsedCommand`, `CommandRegistryEntry`, `PositionalMapping`

### `src/client/commands.ts`
All 29 command schemas organized by category:
- **Core**: `open`, `stop`, `status`, `snapshot`
- **Navigation**: `navigate`, `back`, `forward`, `reload`
- **Interaction**: `click`, `dblclick`, `rightclick`, `type`, `clear`, `check`, `uncheck`, `select`, `focus`, `blur`, `scrollto`, `hover`
- **Keyboard**: `press`
- **Assertion**: `assert`, `asserturl`, `asserttitle`
- **Export**: `export`, `history`, `undo`
- **Wait**: `wait`, `waitfor`

Plus `buildRegistry()` and `commandRegistry` singleton for positional arg mapping.

### `src/client/index.ts`
Updated to export public API from command and commands modules.

### `tests/unit/client/commands.test.ts`
43 tests covering:
- `declareCommand` creation and freezing
- All command categories and schema validation
- `parseCommand` for every command type (positional args, options, multi-word text joining)
- Error handling: unknown commands, missing required args, empty input
- Registry integrity checks

## Verification

- `npx tsc --noEmit` passes
- `npx vitest run` - 43 tests pass
