### PR TITLE
feat: CLI client and argument parsing

### DIFF
--- a/bin/cypress-cli.js
+++ b/bin/cypress-cli.js
@@ -1,0 +1,14 @@
+#!/usr/bin/env node
+
+/**
+ * cypress-cli binary shim.
+ *
+ * This file is the npm-installed `cypress-cli` command.
+ * It simply imports and runs the compiled CLI entry point.
+ */
+
+import { run } from '../dist/client/cli.js';
+
+run(process.argv.slice(2)).then((exitCode) => {
+	process.exitCode = exitCode;
+});

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,17 @@
+import js from '@eslint/js';
+import tseslint from 'typescript-eslint';
+
+export default tseslint.config(
+	js.configs.recommended,
+	...tseslint.configs.recommended,
+	{
+		files: ['src/**/*.ts', 'tests/**/*.ts'],
+		rules: {
+			'@typescript-eslint/no-unused-vars': ['warn', { argsIgnorePattern: '^_' }],
+			'@typescript-eslint/no-explicit-any': 'warn',
+		},
+	},
+	{
+		ignores: ['dist/', 'node_modules/', '*.config.*', 'esbuild.config.js'],
+	},
+);

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
 				"zod": "3.24.2"
 			},
 			"bin": {
-				"cypress-cli": "dist/client/index.js"
+				"cypress-cli": "bin/cypress-cli.js"
 			},
 			"devDependencies": {
 				"@types/minimist": "1.2.5",
@@ -23,6 +23,7 @@
 				"eslint": "9.21.0",
 				"happy-dom": "17.4.4",
 				"typescript": "5.7.3",
+				"typescript-eslint": "^8.25.0",
 				"vitest": "3.0.7"
 			},
 			"engines": {
@@ -675,6 +676,41 @@
 			"integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
 			"dev": true
 		},
+		"node_modules/@nodelib/fs.scandir": {
+			"version": "2.1.5",
+			"resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+			"integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+			"dev": true,
+			"dependencies": {
+				"@nodelib/fs.stat": "2.0.5",
+				"run-parallel": "^1.1.9"
+			},
+			"engines": {
+				"node": ">= 8"
+			}
+		},
+		"node_modules/@nodelib/fs.stat": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+			"integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+			"dev": true,
+			"engines": {
+				"node": ">= 8"
+			}
+		},
+		"node_modules/@nodelib/fs.walk": {
+			"version": "1.2.8",
+			"resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+			"integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+			"dev": true,
+			"dependencies": {
+				"@nodelib/fs.scandir": "2.1.5",
+				"fastq": "^1.6.0"
+			},
+			"engines": {
+				"node": ">= 8"
+			}
+		},
 		"node_modules/@rollup/rollup-android-arm-eabi": {
 			"version": "4.59.0",
 			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.59.0.tgz",
@@ -1047,6 +1083,202 @@
 			"optional": true,
 			"dependencies": {
 				"@types/node": "*"
+			}
+		},
+		"node_modules/@typescript-eslint/eslint-plugin": {
+			"version": "8.25.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.25.0.tgz",
+			"integrity": "sha512-VM7bpzAe7JO/BFf40pIT1lJqS/z1F8OaSsUB3rpFJucQA4cOSuH2RVVVkFULN+En0Djgr29/jb4EQnedUo95KA==",
+			"dev": true,
+			"dependencies": {
+				"@eslint-community/regexpp": "^4.10.0",
+				"@typescript-eslint/scope-manager": "8.25.0",
+				"@typescript-eslint/type-utils": "8.25.0",
+				"@typescript-eslint/utils": "8.25.0",
+				"@typescript-eslint/visitor-keys": "8.25.0",
+				"graphemer": "^1.4.0",
+				"ignore": "^5.3.1",
+				"natural-compare": "^1.4.0",
+				"ts-api-utils": "^2.0.1"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependencies": {
+				"@typescript-eslint/parser": "^8.0.0 || ^8.0.0-alpha.0",
+				"eslint": "^8.57.0 || ^9.0.0",
+				"typescript": ">=4.8.4 <5.8.0"
+			}
+		},
+		"node_modules/@typescript-eslint/parser": {
+			"version": "8.25.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.25.0.tgz",
+			"integrity": "sha512-4gbs64bnbSzu4FpgMiQ1A+D+urxkoJk/kqlDJ2W//5SygaEiAP2B4GoS7TEdxgwol2el03gckFV9lJ4QOMiiHg==",
+			"dev": true,
+			"dependencies": {
+				"@typescript-eslint/scope-manager": "8.25.0",
+				"@typescript-eslint/types": "8.25.0",
+				"@typescript-eslint/typescript-estree": "8.25.0",
+				"@typescript-eslint/visitor-keys": "8.25.0",
+				"debug": "^4.3.4"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependencies": {
+				"eslint": "^8.57.0 || ^9.0.0",
+				"typescript": ">=4.8.4 <5.8.0"
+			}
+		},
+		"node_modules/@typescript-eslint/scope-manager": {
+			"version": "8.25.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.25.0.tgz",
+			"integrity": "sha512-6PPeiKIGbgStEyt4NNXa2ru5pMzQ8OYKO1hX1z53HMomrmiSB+R5FmChgQAP1ro8jMtNawz+TRQo/cSXrauTpg==",
+			"dev": true,
+			"dependencies": {
+				"@typescript-eslint/types": "8.25.0",
+				"@typescript-eslint/visitor-keys": "8.25.0"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			}
+		},
+		"node_modules/@typescript-eslint/type-utils": {
+			"version": "8.25.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.25.0.tgz",
+			"integrity": "sha512-d77dHgHWnxmXOPJuDWO4FDWADmGQkN5+tt6SFRZz/RtCWl4pHgFl3+WdYCn16+3teG09DY6XtEpf3gGD0a186g==",
+			"dev": true,
+			"dependencies": {
+				"@typescript-eslint/typescript-estree": "8.25.0",
+				"@typescript-eslint/utils": "8.25.0",
+				"debug": "^4.3.4",
+				"ts-api-utils": "^2.0.1"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependencies": {
+				"eslint": "^8.57.0 || ^9.0.0",
+				"typescript": ">=4.8.4 <5.8.0"
+			}
+		},
+		"node_modules/@typescript-eslint/types": {
+			"version": "8.25.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.25.0.tgz",
+			"integrity": "sha512-+vUe0Zb4tkNgznQwicsvLUJgZIRs6ITeWSCclX1q85pR1iOiaj+4uZJIUp//Z27QWu5Cseiw3O3AR8hVpax7Aw==",
+			"dev": true,
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			}
+		},
+		"node_modules/@typescript-eslint/typescript-estree": {
+			"version": "8.25.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.25.0.tgz",
+			"integrity": "sha512-ZPaiAKEZ6Blt/TPAx5Ot0EIB/yGtLI2EsGoY6F7XKklfMxYQyvtL+gT/UCqkMzO0BVFHLDlzvFqQzurYahxv9Q==",
+			"dev": true,
+			"dependencies": {
+				"@typescript-eslint/types": "8.25.0",
+				"@typescript-eslint/visitor-keys": "8.25.0",
+				"debug": "^4.3.4",
+				"fast-glob": "^3.3.2",
+				"is-glob": "^4.0.3",
+				"minimatch": "^9.0.4",
+				"semver": "^7.6.0",
+				"ts-api-utils": "^2.0.1"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependencies": {
+				"typescript": ">=4.8.4 <5.8.0"
+			}
+		},
+		"node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+			"integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+			"dev": true,
+			"dependencies": {
+				"balanced-match": "^1.0.0"
+			}
+		},
+		"node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
+			"version": "9.0.9",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+			"integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+			"dev": true,
+			"dependencies": {
+				"brace-expansion": "^2.0.2"
+			},
+			"engines": {
+				"node": ">=16 || 14 >=14.17"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/@typescript-eslint/utils": {
+			"version": "8.25.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.25.0.tgz",
+			"integrity": "sha512-syqRbrEv0J1wywiLsK60XzHnQe/kRViI3zwFALrNEgnntn1l24Ra2KvOAWwWbWZ1lBZxZljPDGOq967dsl6fkA==",
+			"dev": true,
+			"dependencies": {
+				"@eslint-community/eslint-utils": "^4.4.0",
+				"@typescript-eslint/scope-manager": "8.25.0",
+				"@typescript-eslint/types": "8.25.0",
+				"@typescript-eslint/typescript-estree": "8.25.0"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependencies": {
+				"eslint": "^8.57.0 || ^9.0.0",
+				"typescript": ">=4.8.4 <5.8.0"
+			}
+		},
+		"node_modules/@typescript-eslint/visitor-keys": {
+			"version": "8.25.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.25.0.tgz",
+			"integrity": "sha512-kCYXKAum9CecGVHGij7muybDfTS2sD3t0L4bJsEZLkyrXUImiCTq1M3LG2SRtOhiHFwMR9wAFplpT6XHYjTkwQ==",
+			"dev": true,
+			"dependencies": {
+				"@typescript-eslint/types": "8.25.0",
+				"eslint-visitor-keys": "^4.2.0"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
 			}
 		},
 		"node_modules/@vitest/expect": {
@@ -1430,6 +1662,18 @@
 			"dependencies": {
 				"balanced-match": "^1.0.0",
 				"concat-map": "0.0.1"
+			}
+		},
+		"node_modules/braces": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+			"integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+			"dev": true,
+			"dependencies": {
+				"fill-range": "^7.1.1"
+			},
+			"engines": {
+				"node": ">=8"
 			}
 		},
 		"node_modules/buffer": {
@@ -2254,6 +2498,34 @@
 			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
 			"dev": true
 		},
+		"node_modules/fast-glob": {
+			"version": "3.3.3",
+			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+			"integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+			"dev": true,
+			"dependencies": {
+				"@nodelib/fs.stat": "^2.0.2",
+				"@nodelib/fs.walk": "^1.2.3",
+				"glob-parent": "^5.1.2",
+				"merge2": "^1.3.0",
+				"micromatch": "^4.0.8"
+			},
+			"engines": {
+				"node": ">=8.6.0"
+			}
+		},
+		"node_modules/fast-glob/node_modules/glob-parent": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+			"integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+			"dev": true,
+			"dependencies": {
+				"is-glob": "^4.0.1"
+			},
+			"engines": {
+				"node": ">= 6"
+			}
+		},
 		"node_modules/fast-json-stable-stringify": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
@@ -2265,6 +2537,15 @@
 			"resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
 			"integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
 			"dev": true
+		},
+		"node_modules/fastq": {
+			"version": "1.20.1",
+			"resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
+			"integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
+			"dev": true,
+			"dependencies": {
+				"reusify": "^1.0.4"
+			}
 		},
 		"node_modules/fd-slicer": {
 			"version": "1.1.0",
@@ -2326,6 +2607,18 @@
 			},
 			"engines": {
 				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/fill-range": {
+			"version": "7.1.1",
+			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+			"integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+			"dev": true,
+			"dependencies": {
+				"to-regex-range": "^5.0.1"
+			},
+			"engines": {
+				"node": ">=8"
 			}
 		},
 		"node_modules/find-up": {
@@ -2553,6 +2846,12 @@
 			"integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
 			"dev": true
 		},
+		"node_modules/graphemer": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
+			"integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
+			"dev": true
+		},
 		"node_modules/happy-dom": {
 			"version": "17.4.4",
 			"resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-17.4.4.tgz",
@@ -2753,6 +3052,15 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/is-number": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+			"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.12.0"
 			}
 		},
 		"node_modules/is-path-inside": {
@@ -3066,6 +3374,40 @@
 			"resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
 			"integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
 			"dev": true
+		},
+		"node_modules/merge2": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+			"integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+			"dev": true,
+			"engines": {
+				"node": ">= 8"
+			}
+		},
+		"node_modules/micromatch": {
+			"version": "4.0.8",
+			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+			"integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+			"dev": true,
+			"dependencies": {
+				"braces": "^3.0.3",
+				"picomatch": "^2.3.1"
+			},
+			"engines": {
+				"node": ">=8.6"
+			}
+		},
+		"node_modules/micromatch/node_modules/picomatch": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+			"integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+			"dev": true,
+			"engines": {
+				"node": ">=8.6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/jonschlinkert"
+			}
 		},
 		"node_modules/mime-db": {
 			"version": "1.52.0",
@@ -3445,6 +3787,26 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/queue-microtask": {
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+			"integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			]
+		},
 		"node_modules/request-progress": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/request-progress/-/request-progress-3.0.0.tgz",
@@ -3474,6 +3836,16 @@
 			},
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/reusify": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+			"integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+			"dev": true,
+			"engines": {
+				"iojs": ">=1.0.0",
+				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/rfdc": {
@@ -3524,6 +3896,29 @@
 				"@rollup/rollup-win32-x64-gnu": "4.59.0",
 				"@rollup/rollup-win32-x64-msvc": "4.59.0",
 				"fsevents": "~2.3.2"
+			}
+		},
+		"node_modules/run-parallel": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+			"integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"dependencies": {
+				"queue-microtask": "^1.2.2"
 			}
 		},
 		"node_modules/rxjs": {
@@ -3897,6 +4292,18 @@
 				"node": ">=14.14"
 			}
 		},
+		"node_modules/to-regex-range": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+			"integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+			"dev": true,
+			"dependencies": {
+				"is-number": "^7.0.0"
+			},
+			"engines": {
+				"node": ">=8.0"
+			}
+		},
 		"node_modules/tough-cookie": {
 			"version": "5.1.2",
 			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
@@ -3916,6 +4323,18 @@
 			"dev": true,
 			"bin": {
 				"tree-kill": "cli.js"
+			}
+		},
+		"node_modules/ts-api-utils": {
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.4.0.tgz",
+			"integrity": "sha512-3TaVTaAv2gTiMB35i3FiGJaRfwb3Pyn/j3m/bfAvGe8FB7CF6u+LMYqYlDh7reQf7UNvoTvdfAqHGmPGOSsPmA==",
+			"dev": true,
+			"engines": {
+				"node": ">=18.12"
+			},
+			"peerDependencies": {
+				"typescript": ">=4.8.4"
 			}
 		},
 		"node_modules/tslib": {
@@ -3977,6 +4396,28 @@
 			},
 			"engines": {
 				"node": ">=14.17"
+			}
+		},
+		"node_modules/typescript-eslint": {
+			"version": "8.25.0",
+			"resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.25.0.tgz",
+			"integrity": "sha512-TxRdQQLH4g7JkoFlYG3caW5v1S6kEkz8rqt80iQJZUYPq1zD1Ra7HfQBJJ88ABRaMvHAXnwRvRB4V+6sQ9xN5Q==",
+			"dev": true,
+			"dependencies": {
+				"@typescript-eslint/eslint-plugin": "8.25.0",
+				"@typescript-eslint/parser": "8.25.0",
+				"@typescript-eslint/utils": "8.25.0"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependencies": {
+				"eslint": "^8.57.0 || ^9.0.0",
+				"typescript": ">=4.8.4 <5.8.0"
 			}
 		},
 		"node_modules/undici-types": {
@@ -4669,6 +5110,32 @@
 			"integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
 			"dev": true
 		},
+		"@nodelib/fs.scandir": {
+			"version": "2.1.5",
+			"resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+			"integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+			"dev": true,
+			"requires": {
+				"@nodelib/fs.stat": "2.0.5",
+				"run-parallel": "^1.1.9"
+			}
+		},
+		"@nodelib/fs.stat": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+			"integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+			"dev": true
+		},
+		"@nodelib/fs.walk": {
+			"version": "1.2.8",
+			"resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+			"integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+			"dev": true,
+			"requires": {
+				"@nodelib/fs.scandir": "2.1.5",
+				"fastq": "^1.6.0"
+			}
+		},
 		"@rollup/rollup-android-arm-eabi": {
 			"version": "4.59.0",
 			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.59.0.tgz",
@@ -4891,6 +5358,122 @@
 			"optional": true,
 			"requires": {
 				"@types/node": "*"
+			}
+		},
+		"@typescript-eslint/eslint-plugin": {
+			"version": "8.25.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.25.0.tgz",
+			"integrity": "sha512-VM7bpzAe7JO/BFf40pIT1lJqS/z1F8OaSsUB3rpFJucQA4cOSuH2RVVVkFULN+En0Djgr29/jb4EQnedUo95KA==",
+			"dev": true,
+			"requires": {
+				"@eslint-community/regexpp": "^4.10.0",
+				"@typescript-eslint/scope-manager": "8.25.0",
+				"@typescript-eslint/type-utils": "8.25.0",
+				"@typescript-eslint/utils": "8.25.0",
+				"@typescript-eslint/visitor-keys": "8.25.0",
+				"graphemer": "^1.4.0",
+				"ignore": "^5.3.1",
+				"natural-compare": "^1.4.0",
+				"ts-api-utils": "^2.0.1"
+			}
+		},
+		"@typescript-eslint/parser": {
+			"version": "8.25.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.25.0.tgz",
+			"integrity": "sha512-4gbs64bnbSzu4FpgMiQ1A+D+urxkoJk/kqlDJ2W//5SygaEiAP2B4GoS7TEdxgwol2el03gckFV9lJ4QOMiiHg==",
+			"dev": true,
+			"requires": {
+				"@typescript-eslint/scope-manager": "8.25.0",
+				"@typescript-eslint/types": "8.25.0",
+				"@typescript-eslint/typescript-estree": "8.25.0",
+				"@typescript-eslint/visitor-keys": "8.25.0",
+				"debug": "^4.3.4"
+			}
+		},
+		"@typescript-eslint/scope-manager": {
+			"version": "8.25.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.25.0.tgz",
+			"integrity": "sha512-6PPeiKIGbgStEyt4NNXa2ru5pMzQ8OYKO1hX1z53HMomrmiSB+R5FmChgQAP1ro8jMtNawz+TRQo/cSXrauTpg==",
+			"dev": true,
+			"requires": {
+				"@typescript-eslint/types": "8.25.0",
+				"@typescript-eslint/visitor-keys": "8.25.0"
+			}
+		},
+		"@typescript-eslint/type-utils": {
+			"version": "8.25.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.25.0.tgz",
+			"integrity": "sha512-d77dHgHWnxmXOPJuDWO4FDWADmGQkN5+tt6SFRZz/RtCWl4pHgFl3+WdYCn16+3teG09DY6XtEpf3gGD0a186g==",
+			"dev": true,
+			"requires": {
+				"@typescript-eslint/typescript-estree": "8.25.0",
+				"@typescript-eslint/utils": "8.25.0",
+				"debug": "^4.3.4",
+				"ts-api-utils": "^2.0.1"
+			}
+		},
+		"@typescript-eslint/types": {
+			"version": "8.25.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.25.0.tgz",
+			"integrity": "sha512-+vUe0Zb4tkNgznQwicsvLUJgZIRs6ITeWSCclX1q85pR1iOiaj+4uZJIUp//Z27QWu5Cseiw3O3AR8hVpax7Aw==",
+			"dev": true
+		},
+		"@typescript-eslint/typescript-estree": {
+			"version": "8.25.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.25.0.tgz",
+			"integrity": "sha512-ZPaiAKEZ6Blt/TPAx5Ot0EIB/yGtLI2EsGoY6F7XKklfMxYQyvtL+gT/UCqkMzO0BVFHLDlzvFqQzurYahxv9Q==",
+			"dev": true,
+			"requires": {
+				"@typescript-eslint/types": "8.25.0",
+				"@typescript-eslint/visitor-keys": "8.25.0",
+				"debug": "^4.3.4",
+				"fast-glob": "^3.3.2",
+				"is-glob": "^4.0.3",
+				"minimatch": "^9.0.4",
+				"semver": "^7.6.0",
+				"ts-api-utils": "^2.0.1"
+			},
+			"dependencies": {
+				"brace-expansion": {
+					"version": "2.0.2",
+					"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+					"integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+					"dev": true,
+					"requires": {
+						"balanced-match": "^1.0.0"
+					}
+				},
+				"minimatch": {
+					"version": "9.0.9",
+					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+					"integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+					"dev": true,
+					"requires": {
+						"brace-expansion": "^2.0.2"
+					}
+				}
+			}
+		},
+		"@typescript-eslint/utils": {
+			"version": "8.25.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.25.0.tgz",
+			"integrity": "sha512-syqRbrEv0J1wywiLsK60XzHnQe/kRViI3zwFALrNEgnntn1l24Ra2KvOAWwWbWZ1lBZxZljPDGOq967dsl6fkA==",
+			"dev": true,
+			"requires": {
+				"@eslint-community/eslint-utils": "^4.4.0",
+				"@typescript-eslint/scope-manager": "8.25.0",
+				"@typescript-eslint/types": "8.25.0",
+				"@typescript-eslint/typescript-estree": "8.25.0"
+			}
+		},
+		"@typescript-eslint/visitor-keys": {
+			"version": "8.25.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.25.0.tgz",
+			"integrity": "sha512-kCYXKAum9CecGVHGij7muybDfTS2sD3t0L4bJsEZLkyrXUImiCTq1M3LG2SRtOhiHFwMR9wAFplpT6XHYjTkwQ==",
+			"dev": true,
+			"requires": {
+				"@typescript-eslint/types": "8.25.0",
+				"eslint-visitor-keys": "^4.2.0"
 			}
 		},
 		"@vitest/expect": {
@@ -5163,6 +5746,15 @@
 			"requires": {
 				"balanced-match": "^1.0.0",
 				"concat-map": "0.0.1"
+			}
+		},
+		"braces": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+			"integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+			"dev": true,
+			"requires": {
+				"fill-range": "^7.1.1"
 			}
 		},
 		"buffer": {
@@ -5770,6 +6362,30 @@
 			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
 			"dev": true
 		},
+		"fast-glob": {
+			"version": "3.3.3",
+			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+			"integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+			"dev": true,
+			"requires": {
+				"@nodelib/fs.stat": "^2.0.2",
+				"@nodelib/fs.walk": "^1.2.3",
+				"glob-parent": "^5.1.2",
+				"merge2": "^1.3.0",
+				"micromatch": "^4.0.8"
+			},
+			"dependencies": {
+				"glob-parent": {
+					"version": "5.1.2",
+					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+					"integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+					"dev": true,
+					"requires": {
+						"is-glob": "^4.0.1"
+					}
+				}
+			}
+		},
 		"fast-json-stable-stringify": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
@@ -5781,6 +6397,15 @@
 			"resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
 			"integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
 			"dev": true
+		},
+		"fastq": {
+			"version": "1.20.1",
+			"resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
+			"integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
+			"dev": true,
+			"requires": {
+				"reusify": "^1.0.4"
+			}
 		},
 		"fd-slicer": {
 			"version": "1.1.0",
@@ -5822,6 +6447,15 @@
 			"dev": true,
 			"requires": {
 				"flat-cache": "^4.0.0"
+			}
+		},
+		"fill-range": {
+			"version": "7.1.1",
+			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+			"integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+			"dev": true,
+			"requires": {
+				"to-regex-range": "^5.0.1"
 			}
 		},
 		"find-up": {
@@ -5985,6 +6619,12 @@
 			"integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
 			"dev": true
 		},
+		"graphemer": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
+			"integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
+			"dev": true
+		},
 		"happy-dom": {
 			"version": "17.4.4",
 			"resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-17.4.4.tgz",
@@ -6112,6 +6752,12 @@
 				"global-dirs": "^3.0.0",
 				"is-path-inside": "^3.0.2"
 			}
+		},
+		"is-number": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+			"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+			"dev": true
 		},
 		"is-path-inside": {
 			"version": "3.0.3",
@@ -6356,6 +7002,30 @@
 			"resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
 			"integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
 			"dev": true
+		},
+		"merge2": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+			"integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+			"dev": true
+		},
+		"micromatch": {
+			"version": "4.0.8",
+			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+			"integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+			"dev": true,
+			"requires": {
+				"braces": "^3.0.3",
+				"picomatch": "^2.3.1"
+			},
+			"dependencies": {
+				"picomatch": {
+					"version": "2.3.1",
+					"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+					"integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+					"dev": true
+				}
+			}
 		},
 		"mime-db": {
 			"version": "1.52.0",
@@ -6613,6 +7283,12 @@
 				"side-channel": "^1.1.0"
 			}
 		},
+		"queue-microtask": {
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+			"integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+			"dev": true
+		},
 		"request-progress": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/request-progress/-/request-progress-3.0.0.tgz",
@@ -6637,6 +7313,12 @@
 				"onetime": "^5.1.0",
 				"signal-exit": "^3.0.2"
 			}
+		},
+		"reusify": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+			"integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+			"dev": true
 		},
 		"rfdc": {
 			"version": "1.4.1",
@@ -6677,6 +7359,15 @@
 				"@rollup/rollup-win32-x64-msvc": "4.59.0",
 				"@types/estree": "1.0.8",
 				"fsevents": "~2.3.2"
+			}
+		},
+		"run-parallel": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+			"integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+			"dev": true,
+			"requires": {
+				"queue-microtask": "^1.2.2"
 			}
 		},
 		"rxjs": {
@@ -6941,6 +7632,15 @@
 			"integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
 			"dev": true
 		},
+		"to-regex-range": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+			"integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+			"dev": true,
+			"requires": {
+				"is-number": "^7.0.0"
+			}
+		},
 		"tough-cookie": {
 			"version": "5.1.2",
 			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
@@ -6955,6 +7655,13 @@
 			"resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
 			"integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
 			"dev": true
+		},
+		"ts-api-utils": {
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.4.0.tgz",
+			"integrity": "sha512-3TaVTaAv2gTiMB35i3FiGJaRfwb3Pyn/j3m/bfAvGe8FB7CF6u+LMYqYlDh7reQf7UNvoTvdfAqHGmPGOSsPmA==",
+			"dev": true,
+			"requires": {}
 		},
 		"tslib": {
 			"version": "2.8.1",
@@ -6997,6 +7704,17 @@
 			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
 			"integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
 			"dev": true
+		},
+		"typescript-eslint": {
+			"version": "8.25.0",
+			"resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.25.0.tgz",
+			"integrity": "sha512-TxRdQQLH4g7JkoFlYG3caW5v1S6kEkz8rqt80iQJZUYPq1zD1Ra7HfQBJJ88ABRaMvHAXnwRvRB4V+6sQ9xN5Q==",
+			"dev": true,
+			"requires": {
+				"@typescript-eslint/eslint-plugin": "8.25.0",
+				"@typescript-eslint/parser": "8.25.0",
+				"@typescript-eslint/utils": "8.25.0"
+			}
 		},
 		"undici-types": {
 			"version": "6.20.0",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
 	"description": "CLI tool for REPL-like LLM interactions with Cypress tests via Playwright's aria snapshot",
 	"type": "module",
 	"bin": {
-		"cypress-cli": "./dist/client/index.js"
+		"cypress-cli": "./bin/cypress-cli.js"
 	},
 	"scripts": {
 		"build": "npm run build:iife && npm run build:ts",
@@ -37,10 +37,12 @@
 		"eslint": "9.21.0",
 		"happy-dom": "17.4.4",
 		"typescript": "5.7.3",
+		"typescript-eslint": "^8.25.0",
 		"vitest": "3.0.7"
 	},
 	"files": [
 		"dist/",
+		"bin/",
 		"README.md",
 		"LICENSE"
 	],

--- a/src/client/cli.ts
+++ b/src/client/cli.ts
@@ -1,0 +1,225 @@
+/**
+ * CLI entry point: parses arguments with minimist, validates with zod,
+ * and dispatches the command to the daemon over a Unix domain socket.
+ *
+ * Exit codes:
+ *   0 — success
+ *   1 — command error (daemon returned an error)
+ *   2 — connection error (daemon not reachable)
+ *   3 — validation error (bad args / unknown command)
+ */
+
+import minimist from 'minimist';
+
+import { parseCommand, CommandValidationError } from './command.js';
+import { commandRegistry } from './commands.js';
+import { ClientSession } from './session.js';
+import { startRepl } from './repl.js';
+
+// ---------------------------------------------------------------------------
+// Exit codes
+// ---------------------------------------------------------------------------
+
+/** Command completed successfully. */
+export const EXIT_SUCCESS = 0;
+/** Daemon returned an error for the command. */
+export const EXIT_COMMAND_ERROR = 1;
+/** Could not connect to the daemon. */
+export const EXIT_CONNECTION_ERROR = 2;
+/** CLI argument validation failed. */
+export const EXIT_VALIDATION_ERROR = 3;
+
+// ---------------------------------------------------------------------------
+// Argument parsing
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse raw process.argv into a minimist result.
+ *
+ * @param argv - Raw argument array (typically process.argv.slice(2))
+ * @returns Minimist-parsed arguments
+ */
+export function parseArgs(argv: string[]): minimist.ParsedArgs {
+	return minimist(argv, {
+		boolean: ['json', 'help', 'version', 'force', 'multiple', 'headed', 'diff'],
+		string: ['session', 'file', 'browser', 'config', 'timeout'],
+		alias: {
+			h: 'help',
+			v: 'version',
+			s: 'session',
+			j: 'json',
+		},
+	});
+}
+
+// ---------------------------------------------------------------------------
+// Help / version
+// ---------------------------------------------------------------------------
+
+const HELP_TEXT = `Usage: cypress-cli <command> [args] [options]
+
+Commands:
+  open [url]                      Start a session
+  stop                            Stop the current session
+  status                          Check if a session is running
+  snapshot [--diff]               Get current aria snapshot
+  navigate <url>                  Navigate to a URL
+  back / forward / reload         Browser navigation
+  click <ref>                     Click an element
+  type <ref> <text>               Type text into an element
+  assert <ref> <chainer> [value]  Assert on an element
+  export [--file path]            Export as .cy.ts test file
+  history                         List executed commands
+  repl                            Interactive REPL mode
+
+Options:
+  --json                          Output machine-readable JSON
+  --session <id>                  Target a specific session
+  --help, -h                      Show this help
+  --version, -v                   Show version
+
+Exit codes:
+  0  Success
+  1  Command error
+  2  Connection error
+  3  Validation error
+`;
+
+const VERSION = '0.1.0';
+
+// ---------------------------------------------------------------------------
+// Output formatting
+// ---------------------------------------------------------------------------
+
+/**
+ * Format a successful command result for terminal output.
+ *
+ * @param result - The daemon response result
+ * @param isJson - Whether to output JSON
+ * @returns Formatted string
+ */
+export function formatResult(
+	result: { success: boolean; snapshot?: string; selector?: string; cypressCommand?: string },
+	isJson: boolean,
+): string {
+	if (isJson) {
+		return JSON.stringify(result);
+	}
+
+	const parts: string[] = [];
+
+	if (result.snapshot) {
+		parts.push(result.snapshot);
+	}
+
+	if (result.cypressCommand) {
+		parts.push(`> ${result.cypressCommand}`);
+	}
+
+	if (parts.length === 0) {
+		parts.push('OK');
+	}
+
+	return parts.join('\n');
+}
+
+/**
+ * Format an error for terminal output.
+ *
+ * @param error - Error message string
+ * @param isJson - Whether to output JSON
+ * @returns Formatted string
+ */
+export function formatError(error: string, isJson: boolean): string {
+	if (isJson) {
+		return JSON.stringify({ error });
+	}
+	return `Error: ${error}`;
+}
+
+// ---------------------------------------------------------------------------
+// Main CLI runner
+// ---------------------------------------------------------------------------
+
+/**
+ * Run the CLI with the given arguments.
+ *
+ * @param argv - Raw argument array (typically process.argv.slice(2))
+ * @param options - Overrides for testing (socketPath, output streams)
+ * @returns Exit code
+ */
+export async function run(
+	argv: string[],
+	options: {
+		socketPath?: string;
+		stdout?: { write(s: string): void };
+		stderr?: { write(s: string): void };
+	} = {},
+): Promise<number> {
+	const stdout = options.stdout ?? process.stdout;
+	const stderr = options.stderr ?? process.stderr;
+
+	// Parse CLI arguments
+	const parsed = parseArgs(argv);
+	const isJson = Boolean(parsed['json']);
+	const sessionId = (parsed['session'] as string | undefined) ?? 'default';
+
+	// Handle --version
+	if (parsed['version']) {
+		stdout.write(VERSION + '\n');
+		return EXIT_SUCCESS;
+	}
+
+	// Handle --help
+	if (parsed['help'] || parsed._.length === 0) {
+		stdout.write(HELP_TEXT);
+		return EXIT_SUCCESS;
+	}
+
+	// Handle REPL mode
+	const commandName = parsed._[0];
+	if (commandName === 'repl') {
+		const socketPath = options.socketPath ?? ClientSession.defaultSocketPath(sessionId);
+		try {
+			await startRepl({ socketPath, isJson, stdout, stderr });
+			return EXIT_SUCCESS;
+		} catch (err) {
+			stderr.write(formatError(
+				err instanceof Error ? err.message : String(err),
+				isJson,
+			) + '\n');
+			return EXIT_CONNECTION_ERROR;
+		}
+	}
+
+	// Validate command against registry
+	let parsedCommand;
+	try {
+		parsedCommand = parseCommand(parsed, commandRegistry);
+	} catch (err) {
+		if (err instanceof CommandValidationError) {
+			stderr.write(formatError(err.message, isJson) + '\n');
+			return EXIT_VALIDATION_ERROR;
+		}
+		throw err;
+	}
+
+	// Connect to daemon and send command
+	const socketPath = options.socketPath ?? ClientSession.defaultSocketPath(sessionId);
+	const session = new ClientSession(socketPath);
+
+	try {
+		const response = await session.sendCommand(parsedCommand, parsed);
+		if ('error' in response) {
+			stderr.write(formatError(response.error as string, isJson) + '\n');
+			return EXIT_COMMAND_ERROR;
+		}
+		const result = (response as { result: { success: boolean; snapshot?: string; selector?: string; cypressCommand?: string } }).result;
+		stdout.write(formatResult(result, isJson) + '\n');
+		return EXIT_SUCCESS;
+	} catch (err) {
+		const message = err instanceof Error ? err.message : String(err);
+		stderr.write(formatError(message, isJson) + '\n');
+		return EXIT_CONNECTION_ERROR;
+	}
+}

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -2,5 +2,31 @@
 
 /**
  * CLI entry point for cypress-cli.
+ *
+ * This module re-exports the public API and, when executed directly,
+ * runs the CLI with process.argv.
  */
-export {};
+
+export { run, parseArgs, formatResult, formatError, EXIT_SUCCESS, EXIT_COMMAND_ERROR, EXIT_CONNECTION_ERROR, EXIT_VALIDATION_ERROR } from './cli.js';
+export { ClientSession } from './session.js';
+export { ClientSocketConnection, ClientConnectionError, ClientTimeoutError } from './socketConnection.js';
+export { startRepl, splitArgs } from './repl.js';
+export { parseCommand, CommandValidationError } from './command.js';
+export type { ParsedCommand, CommandSchema, CommandCategory, CommandDefinition, CommandRegistryEntry, PositionalMapping } from './command.js';
+export { commandRegistry, buildRegistry, allCommands } from './commands.js';
+
+import { run } from './cli.js';
+
+/**
+ * When this module is the main entry point, run the CLI.
+ * ES module detection: check if this file is being run directly via node.
+ */
+const isMain = process.argv[1] &&
+	(process.argv[1].endsWith('/client/index.js') ||
+	 process.argv[1].endsWith('/client/index.ts'));
+
+if (isMain) {
+	run(process.argv.slice(2)).then((exitCode) => {
+		process.exitCode = exitCode;
+	});
+}

--- a/src/client/repl.ts
+++ b/src/client/repl.ts
@@ -1,0 +1,170 @@
+/**
+ * Interactive REPL mode for cypress-cli.
+ *
+ * Provides a readline-based REPL loop that:
+ * - Reads commands interactively (or from piped stdin)
+ * - Sends each command to the daemon via ClientSession.sendRaw()
+ * - Prints results inline
+ * - Supports `exit` / `quit` / Ctrl-C to leave
+ *
+ * Usage: `cypress-cli repl [--session <id>] [--json]`
+ */
+
+import readline from 'node:readline';
+
+import { ClientSession } from './session.js';
+import { isErrorMessage } from '../daemon/protocol.js';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/**
+ * Options for the REPL session.
+ */
+export interface ReplOptions {
+	/** Path to the daemon Unix socket. */
+	socketPath: string;
+	/** Whether to output JSON. */
+	isJson: boolean;
+	/** Output stream (defaults to process.stdout). */
+	stdout?: { write(s: string): void };
+	/** Error stream (defaults to process.stderr). */
+	stderr?: { write(s: string): void };
+	/** Input stream (defaults to process.stdin). */
+	stdin?: NodeJS.ReadableStream;
+}
+
+// ---------------------------------------------------------------------------
+// REPL
+// ---------------------------------------------------------------------------
+
+/**
+ * Start an interactive REPL session.
+ *
+ * The REPL connects to the daemon and sends commands line by line.
+ * It exits on `exit`, `quit`, empty EOF, or Ctrl-C.
+ *
+ * @param options - REPL configuration
+ */
+export async function startRepl(options: ReplOptions): Promise<void> {
+	const stdout = options.stdout ?? process.stdout;
+	const stderr = options.stderr ?? process.stderr;
+	const stdin = options.stdin ?? process.stdin;
+
+	const session = new ClientSession(options.socketPath);
+
+	const rl = readline.createInterface({
+		input: stdin,
+		output: stdout as NodeJS.WritableStream,
+		prompt: 'cypress> ',
+		terminal: stdin === process.stdin && (stdin as NodeJS.ReadStream).isTTY === true,
+	});
+
+	stdout.write('cypress-cli REPL (type "exit" or Ctrl-C to quit)\n');
+	rl.prompt();
+
+	return new Promise<void>((resolve) => {
+		rl.on('line', async (line: string) => {
+			const trimmed = line.trim();
+
+			// Skip empty lines
+			if (trimmed.length === 0) {
+				rl.prompt();
+				return;
+			}
+
+			// Exit commands
+			if (trimmed === 'exit' || trimmed === 'quit') {
+				rl.close();
+				return;
+			}
+
+			// Parse into args array — simple split on whitespace
+			// (minimist handles quoted strings, but in REPL mode we do simple split)
+			const args = splitArgs(trimmed);
+
+			try {
+				const response = await session.sendRaw(args);
+
+				if (isErrorMessage(response)) {
+					if (options.isJson) {
+						stderr.write(JSON.stringify({ error: response.error }) + '\n');
+					} else {
+						stderr.write(`Error: ${response.error}\n`);
+					}
+				} else {
+					const result = response.result;
+					if (options.isJson) {
+						stdout.write(JSON.stringify(result) + '\n');
+					} else {
+						if (result.snapshot) {
+							stdout.write(result.snapshot + '\n');
+						}
+						if (result.cypressCommand) {
+							stdout.write(`> ${result.cypressCommand}\n`);
+						}
+						if (!result.snapshot && !result.cypressCommand) {
+							stdout.write('OK\n');
+						}
+					}
+				}
+			} catch (err) {
+				const message = err instanceof Error ? err.message : String(err);
+				if (options.isJson) {
+					stderr.write(JSON.stringify({ error: message }) + '\n');
+				} else {
+					stderr.write(`Error: ${message}\n`);
+				}
+			}
+
+			rl.prompt();
+		});
+
+		rl.on('close', () => {
+			stdout.write('\n');
+			resolve();
+		});
+	});
+}
+
+/**
+ * Split a command string into an args array, respecting quoted strings.
+ *
+ * Handles both single and double quotes. Quotes are stripped from the result.
+ *
+ * @param input - The raw command string
+ * @returns Array of argument strings
+ */
+export function splitArgs(input: string): string[] {
+	const args: string[] = [];
+	let current = '';
+	let inQuote: '"' | "'" | null = null;
+
+	for (let i = 0; i < input.length; i++) {
+		const char = input[i];
+
+		if (inQuote) {
+			if (char === inQuote) {
+				inQuote = null;
+			} else {
+				current += char;
+			}
+		} else if (char === '"' || char === "'") {
+			inQuote = char;
+		} else if (char === ' ' || char === '\t') {
+			if (current.length > 0) {
+				args.push(current);
+				current = '';
+			}
+		} else {
+			current += char;
+		}
+	}
+
+	if (current.length > 0) {
+		args.push(current);
+	}
+
+	return args;
+}

--- a/src/client/session.ts
+++ b/src/client/session.ts
@@ -1,0 +1,113 @@
+/**
+ * Client session: connects to the daemon socket, sends commands, reads responses.
+ *
+ * A ClientSession is a thin wrapper over ClientSocketConnection that maps
+ * ParsedCommand objects to protocol messages and returns typed results.
+ * Each command is a one-shot operation: connect, send, receive, disconnect.
+ *
+ * Modeled after Playwright's Session.run() → SocketConnectionClient.sendAndClose().
+ */
+
+import path from 'node:path';
+import os from 'node:os';
+
+import {
+	ClientSocketConnection,
+	type ClientSocketOptions,
+} from './socketConnection.js';
+import type { ParsedCommand } from './command.js';
+import type {
+	CommandMessage,
+	DaemonMessage,
+} from '../daemon/protocol.js';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Subdirectory under the runtime dir for socket files. */
+const SOCKET_DIR_NAME = 'cypress-cli';
+
+// ---------------------------------------------------------------------------
+// ClientSession
+// ---------------------------------------------------------------------------
+
+/**
+ * A session for sending commands to the daemon.
+ *
+ * Usage:
+ * ```ts
+ * const session = new ClientSession('/tmp/cypress-cli/default.sock');
+ * const response = await session.sendCommand(parsedCmd, rawArgs);
+ * ```
+ */
+export class ClientSession {
+	private _connection: ClientSocketConnection;
+	private _messageId = 0;
+
+	constructor(socketPath: string, options?: Partial<ClientSocketOptions>) {
+		this._connection = new ClientSocketConnection({
+			socketPath,
+			...options,
+		});
+	}
+
+	/**
+	 * Send a parsed command to the daemon and return the response.
+	 *
+	 * @param parsedCommand - The validated command (from parseCommand)
+	 * @param rawArgs - The raw minimist output (contains extra fields like `_`)
+	 * @returns The daemon response (ResponseMessage or ErrorMessage)
+	 */
+	async sendCommand(
+		parsedCommand: ParsedCommand,
+		rawArgs: { _: string[]; [key: string]: unknown },
+	): Promise<DaemonMessage> {
+		const id = ++this._messageId;
+
+		const message: CommandMessage = {
+			id,
+			method: parsedCommand.command === 'stop' ? 'stop' : 'run',
+			params: {
+				args: rawArgs,
+			},
+		};
+
+		return this._connection.sendAndReceive(message);
+	}
+
+	/**
+	 * Send a raw command (as string args) to the daemon.
+	 * Used by the REPL mode.
+	 *
+	 * @param args - The command as an array of strings (e.g., ["click", "e5"])
+	 * @returns The daemon response
+	 */
+	async sendRaw(args: string[]): Promise<DaemonMessage> {
+		const id = ++this._messageId;
+
+		const message: CommandMessage = {
+			id,
+			method: args[0] === 'stop' ? 'stop' : 'run',
+			params: {
+				args: { _: args },
+			},
+		};
+
+		return this._connection.sendAndReceive(message);
+	}
+
+	/**
+	 * Resolve the default socket path for a given session ID.
+	 *
+	 * @param sessionId - The session ID (defaults to "default")
+	 * @returns Absolute path to the Unix socket
+	 */
+	static defaultSocketPath(sessionId: string = 'default'): string {
+		const runtime = process.env['XDG_RUNTIME_DIR'];
+		const baseDir = runtime
+			? path.join(runtime, SOCKET_DIR_NAME)
+			: path.join(process.env['TMPDIR'] || os.tmpdir(), SOCKET_DIR_NAME);
+		return path.join(baseDir, `${sessionId}.sock`);
+	}
+}

--- a/src/client/socketConnection.ts
+++ b/src/client/socketConnection.ts
@@ -1,0 +1,266 @@
+/**
+ * Client-side socket connection to the daemon.
+ *
+ * Handles:
+ * - Connecting to the daemon's Unix domain socket
+ * - Newline-delimited JSON framing (reuses daemon's SocketConnection)
+ * - Reconnect logic with configurable retries
+ * - Error framing with typed errors
+ * - Send-and-receive pattern (one command at a time)
+ *
+ * Modeled after Playwright's SocketConnectionClient.
+ */
+
+import net from 'node:net';
+import { StringDecoder } from 'node:string_decoder';
+
+import {
+	serializeMessage,
+	deserializeMessage,
+	type ProtocolMessage,
+	type DaemonMessage,
+	ProtocolError,
+} from '../daemon/protocol.js';
+
+// ---------------------------------------------------------------------------
+// Configuration
+// ---------------------------------------------------------------------------
+
+/** Default timeout for connecting to the daemon (ms). */
+const DEFAULT_CONNECT_TIMEOUT = 5_000;
+
+/** Default timeout for waiting for a response from the daemon (ms). */
+const DEFAULT_RESPONSE_TIMEOUT = 300_000;
+
+/** Default number of reconnect attempts. */
+const DEFAULT_MAX_RETRIES = 2;
+
+/** Delay between reconnect attempts (ms). */
+const DEFAULT_RETRY_DELAY = 500;
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/**
+ * Options for creating a ClientSocketConnection.
+ */
+export interface ClientSocketOptions {
+	/** Path to the Unix domain socket. */
+	socketPath: string;
+	/** Timeout for connecting (ms). */
+	connectTimeout?: number;
+	/** Timeout for waiting for a response (ms). */
+	responseTimeout?: number;
+	/** Maximum number of reconnect attempts. */
+	maxRetries?: number;
+	/** Delay between reconnect attempts (ms). */
+	retryDelay?: number;
+}
+
+// ---------------------------------------------------------------------------
+// ClientSocketConnection
+// ---------------------------------------------------------------------------
+
+/**
+ * Client-side socket connection to the daemon.
+ *
+ * Provides a send-and-receive pattern: send a command, wait for the response,
+ * then disconnect. The connection is not reused between commands.
+ */
+export class ClientSocketConnection {
+	private _socketPath: string;
+	private _connectTimeout: number;
+	private _responseTimeout: number;
+	private _maxRetries: number;
+	private _retryDelay: number;
+
+	constructor(options: ClientSocketOptions) {
+		this._socketPath = options.socketPath;
+		this._connectTimeout = options.connectTimeout ?? DEFAULT_CONNECT_TIMEOUT;
+		this._responseTimeout = options.responseTimeout ?? DEFAULT_RESPONSE_TIMEOUT;
+		this._maxRetries = options.maxRetries ?? DEFAULT_MAX_RETRIES;
+		this._retryDelay = options.retryDelay ?? DEFAULT_RETRY_DELAY;
+	}
+
+	/**
+	 * Send a protocol message and wait for a single response.
+	 * Opens a new connection, sends the message, waits for the response,
+	 * and closes the connection.
+	 *
+	 * @param message - The protocol message to send
+	 * @returns The daemon's response message
+	 * @throws {ClientConnectionError} If the connection fails after retries
+	 * @throws {ClientTimeoutError} If the response doesn't arrive in time
+	 */
+	async sendAndReceive(message: ProtocolMessage): Promise<DaemonMessage> {
+		let lastError: Error | null = null;
+
+		for (let attempt = 0; attempt <= this._maxRetries; attempt++) {
+			try {
+				return await this._attempt(message);
+			} catch (err) {
+				lastError = err instanceof Error ? err : new Error(String(err));
+
+				// Don't retry on timeout or protocol errors — only connection failures
+				if (err instanceof ClientTimeoutError || err instanceof ProtocolError) {
+					throw err;
+				}
+
+				// Wait before retrying (unless this was the last attempt)
+				if (attempt < this._maxRetries) {
+					await this._sleep(this._retryDelay);
+				}
+			}
+		}
+
+		throw new ClientConnectionError(
+			`Failed to connect to daemon after ${this._maxRetries + 1} attempts. ` +
+				`Socket: ${this._socketPath}. ` +
+				`Last error: ${lastError?.message ?? 'unknown'}. ` +
+				'Is the daemon running? Start a session with `cypress-cli open <url>`.',
+		);
+	}
+
+	/**
+	 * Single connection attempt: connect, send, receive, close.
+	 */
+	private async _attempt(message: ProtocolMessage): Promise<DaemonMessage> {
+		const socket = await this._connect();
+
+		try {
+			return await this._sendAndWait(socket, message);
+		} finally {
+			socket.destroy();
+		}
+	}
+
+	/**
+	 * Connect to the daemon socket with a timeout.
+	 */
+	private _connect(): Promise<net.Socket> {
+		return new Promise<net.Socket>((resolve, reject) => {
+			const socket = net.createConnection(this._socketPath);
+
+			const timer = setTimeout(() => {
+				socket.destroy();
+				reject(
+					new ClientConnectionError(
+						`Connection to daemon timed out after ${this._connectTimeout}ms. ` +
+							`Socket: ${this._socketPath}.`,
+					),
+				);
+			}, this._connectTimeout);
+
+			socket.on('connect', () => {
+				clearTimeout(timer);
+				resolve(socket);
+			});
+
+			socket.on('error', (err: Error) => {
+				clearTimeout(timer);
+				reject(
+					new ClientConnectionError(
+						`Cannot connect to daemon: ${err.message}. ` +
+							`Socket: ${this._socketPath}. ` +
+							'Is the daemon running? Start a session with `cypress-cli open <url>`.',
+					),
+				);
+			});
+		});
+	}
+
+	/**
+	 * Send a message over an established socket and wait for a response.
+	 */
+	private _sendAndWait(
+		socket: net.Socket,
+		message: ProtocolMessage,
+	): Promise<DaemonMessage> {
+		return new Promise<DaemonMessage>((resolve, reject) => {
+			let buffer = '';
+			const decoder = new StringDecoder('utf-8');
+
+			const timer = setTimeout(() => {
+				reject(
+					new ClientTimeoutError(
+						`No response from daemon within ${this._responseTimeout}ms. ` +
+							'The command may still be running in Cypress.',
+					),
+				);
+			}, this._responseTimeout);
+
+			socket.on('data', (chunk: Buffer | string) => {
+				const decoded = typeof chunk === 'string' ? chunk : decoder.write(chunk);
+				buffer += decoded;
+
+				const newlineIndex = buffer.indexOf('\n');
+				if (newlineIndex !== -1) {
+					clearTimeout(timer);
+					const line = buffer.slice(0, newlineIndex);
+
+					try {
+						const response = deserializeMessage(line);
+						resolve(response as DaemonMessage);
+					} catch (err) {
+						reject(err instanceof Error ? err : new Error(String(err)));
+					}
+				}
+			});
+
+			socket.on('error', (err: Error) => {
+				clearTimeout(timer);
+				reject(
+					new ClientConnectionError(
+						`Socket error during command: ${err.message}`,
+					),
+				);
+			});
+
+			socket.on('close', () => {
+				clearTimeout(timer);
+				// If we haven't resolved yet, the daemon closed without responding
+				reject(
+					new ClientConnectionError(
+						'Daemon closed the connection without responding.',
+					),
+				);
+			});
+
+			// Send the message
+			const serialized = serializeMessage(message);
+			socket.write(serialized);
+		});
+	}
+
+	/**
+	 * Sleep for a given duration.
+	 */
+	private _sleep(ms: number): Promise<void> {
+		return new Promise((resolve) => setTimeout(resolve, ms));
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Errors
+// ---------------------------------------------------------------------------
+
+/**
+ * Error thrown when the client cannot connect to the daemon.
+ */
+export class ClientConnectionError extends Error {
+	constructor(message: string) {
+		super(message);
+		this.name = 'ClientConnectionError';
+	}
+}
+
+/**
+ * Error thrown when the daemon does not respond within the timeout.
+ */
+export class ClientTimeoutError extends Error {
+	constructor(message: string) {
+		super(message);
+		this.name = 'ClientTimeoutError';
+	}
+}

--- a/tests/unit/client/cli.test.ts
+++ b/tests/unit/client/cli.test.ts
@@ -1,0 +1,220 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import {
+	run,
+	parseArgs,
+	formatResult,
+	formatError,
+	EXIT_SUCCESS,
+	EXIT_COMMAND_ERROR,
+	EXIT_CONNECTION_ERROR,
+	EXIT_VALIDATION_ERROR,
+} from '../../../src/client/cli.js';
+
+// ---------------------------------------------------------------------------
+// parseArgs
+// ---------------------------------------------------------------------------
+
+describe('parseArgs', () => {
+	it('parses "click e5" correctly', () => {
+		const result = parseArgs(['click', 'e5']);
+		expect(result._).toEqual(['click', 'e5']);
+	});
+
+	it('parses "type e3 hello world" correctly', () => {
+		const result = parseArgs(['type', 'e3', 'hello', 'world']);
+		expect(result._).toEqual(['type', 'e3', 'hello', 'world']);
+	});
+
+	it('parses "navigate https://example.com" correctly', () => {
+		const result = parseArgs(['navigate', 'https://example.com']);
+		expect(result._).toEqual(['navigate', 'https://example.com']);
+	});
+
+	it('parses options with --flag syntax', () => {
+		const result = parseArgs(['click', 'e5', '--force']);
+		expect(result._).toEqual(['click', 'e5']);
+		expect(result['force']).toBe(true);
+	});
+
+	it('parses --json flag as boolean', () => {
+		const result = parseArgs(['status', '--json']);
+		expect(result['json']).toBe(true);
+	});
+
+	it('parses --session flag with value', () => {
+		const result = parseArgs(['click', 'e5', '--session', 'my-session']);
+		expect(result['session']).toBe('my-session');
+	});
+
+	it('parses short aliases', () => {
+		const result = parseArgs(['-h']);
+		expect(result['help']).toBe(true);
+	});
+
+	it('parses -s as session alias', () => {
+		const result = parseArgs(['click', 'e5', '-s', 'sess1']);
+		expect(result['session']).toBe('sess1');
+	});
+
+	it('parses -j as json alias', () => {
+		const result = parseArgs(['-j', 'status']);
+		expect(result['json']).toBe(true);
+	});
+
+	it('parses "assert e5 have.text Hello" correctly', () => {
+		const result = parseArgs(['assert', 'e5', 'have.text', 'Hello']);
+		expect(result._).toEqual(['assert', 'e5', 'have.text', 'Hello']);
+	});
+
+	it('parses --diff as boolean', () => {
+		const result = parseArgs(['snapshot', '--diff']);
+		expect(result['diff']).toBe(true);
+	});
+
+	it('parses --headed as boolean', () => {
+		const result = parseArgs(['open', 'http://localhost', '--headed']);
+		expect(result['headed']).toBe(true);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// formatResult
+// ---------------------------------------------------------------------------
+
+describe('formatResult', () => {
+	it('formats snapshot result as plain text', () => {
+		const result = {
+			success: true,
+			snapshot: '- main:\n  - heading "Hello"',
+		};
+		expect(formatResult(result, false)).toBe('- main:\n  - heading "Hello"');
+	});
+
+	it('formats result as JSON when isJson is true', () => {
+		const result = { success: true, snapshot: '- main' };
+		const output = formatResult(result, true);
+		expect(JSON.parse(output)).toEqual(result);
+	});
+
+	it('includes cypressCommand in plain text', () => {
+		const result = {
+			success: true,
+			snapshot: '- main',
+			cypressCommand: "cy.get('[data-cy=\"btn\"]').click()",
+		};
+		const output = formatResult(result, false);
+		expect(output).toContain('- main');
+		expect(output).toContain("> cy.get('[data-cy=\"btn\"]').click()");
+	});
+
+	it('returns "OK" when no snapshot or command', () => {
+		const result = { success: true };
+		expect(formatResult(result, false)).toBe('OK');
+	});
+});
+
+// ---------------------------------------------------------------------------
+// formatError
+// ---------------------------------------------------------------------------
+
+describe('formatError', () => {
+	it('formats error as plain text', () => {
+		expect(formatError('something broke', false)).toBe('Error: something broke');
+	});
+
+	it('formats error as JSON', () => {
+		const output = formatError('something broke', true);
+		expect(JSON.parse(output)).toEqual({ error: 'something broke' });
+	});
+});
+
+// ---------------------------------------------------------------------------
+// run (integration with mocked socket)
+// ---------------------------------------------------------------------------
+
+describe('run', () => {
+	let stdout: { write: ReturnType<typeof vi.fn>; output: string };
+	let stderr: { write: ReturnType<typeof vi.fn>; output: string };
+
+	beforeEach(() => {
+		stdout = {
+			output: '',
+			write: vi.fn((s: string) => {
+				stdout.output += s;
+			}),
+		};
+		stderr = {
+			output: '',
+			write: vi.fn((s: string) => {
+				stderr.output += s;
+			}),
+		};
+	});
+
+	it('shows help when no args are provided', async () => {
+		const code = await run([], { stdout, stderr });
+		expect(code).toBe(EXIT_SUCCESS);
+		expect(stdout.output).toContain('Usage:');
+	});
+
+	it('shows help with --help flag', async () => {
+		const code = await run(['--help'], { stdout, stderr });
+		expect(code).toBe(EXIT_SUCCESS);
+		expect(stdout.output).toContain('Usage:');
+	});
+
+	it('shows version with --version flag', async () => {
+		const code = await run(['--version'], { stdout, stderr });
+		expect(code).toBe(EXIT_SUCCESS);
+		expect(stdout.output).toContain('0.1.0');
+	});
+
+	it('returns validation error for unknown command', async () => {
+		const code = await run(['unknowncommand'], { stdout, stderr });
+		expect(code).toBe(EXIT_VALIDATION_ERROR);
+		expect(stderr.output).toContain('Unknown command');
+	});
+
+	it('returns validation error for missing required args', async () => {
+		const code = await run(['click'], { stdout, stderr });
+		expect(code).toBe(EXIT_VALIDATION_ERROR);
+		expect(stderr.output).toContain('Invalid arguments');
+	});
+
+	it('returns connection error when daemon is not running', async () => {
+		const code = await run(['status'], {
+			stdout,
+			stderr,
+			socketPath: '/tmp/cypress-cli-test-nonexistent.sock',
+		});
+		expect(code).toBe(EXIT_CONNECTION_ERROR);
+		expect(stderr.output).toContain('Error');
+	});
+
+	it('returns validation error for too many positional args', async () => {
+		const code = await run(['click', 'e5', 'extra', 'args'], { stdout, stderr });
+		expect(code).toBe(EXIT_VALIDATION_ERROR);
+		expect(stderr.output).toContain('Too many positional');
+	});
+
+	it('outputs JSON errors with --json flag', async () => {
+		const code = await run(['unknowncommand', '--json'], { stdout, stderr });
+		expect(code).toBe(EXIT_VALIDATION_ERROR);
+		const parsed = JSON.parse(stderr.output.trim());
+		expect(parsed).toHaveProperty('error');
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Exit code constants
+// ---------------------------------------------------------------------------
+
+describe('exit codes', () => {
+	it('has correct values', () => {
+		expect(EXIT_SUCCESS).toBe(0);
+		expect(EXIT_COMMAND_ERROR).toBe(1);
+		expect(EXIT_CONNECTION_ERROR).toBe(2);
+		expect(EXIT_VALIDATION_ERROR).toBe(3);
+	});
+});

--- a/tests/unit/client/socketConnection.test.ts
+++ b/tests/unit/client/socketConnection.test.ts
@@ -1,0 +1,320 @@
+import { describe, it, expect, afterEach, beforeEach } from 'vitest';
+import net from 'node:net';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+
+import {
+	ClientSocketConnection,
+	ClientConnectionError,
+	ClientTimeoutError,
+} from '../../../src/client/socketConnection.js';
+import {
+	serializeMessage,
+	type ResponseMessage,
+	type ErrorMessage,
+} from '../../../src/daemon/protocol.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+let tmpDir: string;
+let socketPath: string;
+let servers: net.Server[] = [];
+
+beforeEach(async () => {
+	tmpDir = path.join(os.tmpdir(), `cypress-cli-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+	await fs.mkdir(tmpDir, { recursive: true });
+	socketPath = path.join(tmpDir, 'test.sock');
+	servers = [];
+});
+
+afterEach(async () => {
+	for (const server of servers) {
+		await new Promise<void>((resolve) => server.close(() => resolve()));
+	}
+	servers = [];
+	try {
+		await fs.rm(tmpDir, { recursive: true, force: true });
+	} catch {
+		// Best effort cleanup
+	}
+});
+
+function createMockServer(
+	handler: (socket: net.Socket, data: string) => void,
+): Promise<net.Server> {
+	return new Promise<net.Server>((resolve) => {
+		const server = net.createServer((socket) => {
+			let buffer = '';
+			socket.on('data', (chunk) => {
+				buffer += chunk.toString();
+				const idx = buffer.indexOf('\n');
+				if (idx !== -1) {
+					const line = buffer.slice(0, idx);
+					buffer = buffer.slice(idx + 1);
+					handler(socket, line);
+				}
+			});
+		});
+		servers.push(server);
+		server.listen(socketPath, () => resolve(server));
+	});
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('ClientSocketConnection', () => {
+	describe('sendAndReceive', () => {
+		it('sends a message and receives a response', async () => {
+			await createMockServer((socket, data) => {
+				const msg = JSON.parse(data);
+				const response: ResponseMessage = {
+					id: msg.id,
+					result: { success: true, snapshot: '- main' },
+				};
+				socket.write(serializeMessage(response));
+			});
+
+			const conn = new ClientSocketConnection({
+				socketPath,
+				connectTimeout: 2000,
+				responseTimeout: 2000,
+				maxRetries: 0,
+			});
+
+			const response = await conn.sendAndReceive({
+				id: 1,
+				method: 'run',
+				params: { args: { _: ['status'] } },
+			});
+
+			expect('result' in response).toBe(true);
+			if ('result' in response) {
+				expect(response.result.success).toBe(true);
+				expect(response.result.snapshot).toBe('- main');
+			}
+		});
+
+		it('receives error responses', async () => {
+			await createMockServer((socket, data) => {
+				const msg = JSON.parse(data);
+				const response: ErrorMessage = {
+					id: msg.id,
+					error: 'No session running.',
+				};
+				socket.write(serializeMessage(response));
+			});
+
+			const conn = new ClientSocketConnection({
+				socketPath,
+				connectTimeout: 2000,
+				responseTimeout: 2000,
+				maxRetries: 0,
+			});
+
+			const response = await conn.sendAndReceive({
+				id: 1,
+				method: 'run',
+				params: { args: { _: ['click', 'e5'] } },
+			});
+
+			expect('error' in response).toBe(true);
+			if ('error' in response) {
+				expect(response.error).toBe('No session running.');
+			}
+		});
+
+		it('handles split buffers (response split across data events)', async () => {
+			await createMockServer((socket, _data) => {
+				const response: ResponseMessage = {
+					id: 1,
+					result: { success: true, snapshot: '- heading "Test"' },
+				};
+				const serialized = serializeMessage(response);
+				// Split the response across two writes
+				const mid = Math.floor(serialized.length / 2);
+				socket.write(serialized.slice(0, mid));
+				setTimeout(() => {
+					socket.write(serialized.slice(mid));
+				}, 20);
+			});
+
+			const conn = new ClientSocketConnection({
+				socketPath,
+				connectTimeout: 2000,
+				responseTimeout: 2000,
+				maxRetries: 0,
+			});
+
+			const response = await conn.sendAndReceive({
+				id: 1,
+				method: 'run',
+				params: { args: { _: ['snapshot'] } },
+			});
+
+			expect('result' in response).toBe(true);
+			if ('result' in response) {
+				expect(response.result.snapshot).toBe('- heading "Test"');
+			}
+		});
+
+		it('throws ClientConnectionError when socket does not exist', async () => {
+			const conn = new ClientSocketConnection({
+				socketPath: '/tmp/nonexistent-cypress-cli-test.sock',
+				connectTimeout: 500,
+				responseTimeout: 1000,
+				maxRetries: 0,
+			});
+
+			await expect(
+				conn.sendAndReceive({
+					id: 1,
+					method: 'run',
+					params: { args: { _: ['status'] } },
+				}),
+			).rejects.toThrow(ClientConnectionError);
+		});
+
+		it('throws ClientTimeoutError when daemon does not respond', async () => {
+			// Server accepts connection but never responds
+			await createMockServer(() => {
+				// Intentionally empty — no response
+			});
+
+			const conn = new ClientSocketConnection({
+				socketPath,
+				connectTimeout: 2000,
+				responseTimeout: 200,
+				maxRetries: 0,
+			});
+
+			await expect(
+				conn.sendAndReceive({
+					id: 1,
+					method: 'run',
+					params: { args: { _: ['status'] } },
+				}),
+			).rejects.toThrow(ClientTimeoutError);
+		});
+
+		it('retries on connection failure', async () => {
+			let attempts = 0;
+
+			// Create server after a short delay to simulate daemon starting
+			setTimeout(async () => {
+				await createMockServer((socket, data) => {
+					attempts++;
+					const msg = JSON.parse(data);
+					const response: ResponseMessage = {
+						id: msg.id,
+						result: { success: true },
+					};
+					socket.write(serializeMessage(response));
+				});
+			}, 300);
+
+			const conn = new ClientSocketConnection({
+				socketPath,
+				connectTimeout: 1000,
+				responseTimeout: 2000,
+				maxRetries: 3,
+				retryDelay: 200,
+			});
+
+			const response = await conn.sendAndReceive({
+				id: 1,
+				method: 'run',
+				params: { args: { _: ['status'] } },
+			});
+
+			expect('result' in response).toBe(true);
+			expect(attempts).toBe(1);
+		});
+
+		it('reports all attempts in error after max retries', async () => {
+			const conn = new ClientSocketConnection({
+				socketPath: '/tmp/nonexistent-cypress-cli-retry-test.sock',
+				connectTimeout: 100,
+				responseTimeout: 100,
+				maxRetries: 1,
+				retryDelay: 50,
+			});
+
+			try {
+				await conn.sendAndReceive({
+					id: 1,
+					method: 'run',
+					params: { args: { _: ['status'] } },
+				});
+				expect.fail('Should have thrown');
+			} catch (err) {
+				expect(err).toBeInstanceOf(ClientConnectionError);
+				expect((err as Error).message).toContain('2 attempts');
+			}
+		});
+	});
+
+	describe('connection handling', () => {
+		it('closes socket after receiving response (connection per command)', async () => {
+			let connectionCount = 0;
+
+			await createMockServer((socket, data) => {
+				connectionCount++;
+				const msg = JSON.parse(data);
+				const response: ResponseMessage = {
+					id: msg.id,
+					result: { success: true },
+				};
+				socket.write(serializeMessage(response));
+			});
+
+			const conn = new ClientSocketConnection({
+				socketPath,
+				connectTimeout: 2000,
+				responseTimeout: 2000,
+				maxRetries: 0,
+			});
+
+			// Send two commands sequentially — each should create a new connection
+			await conn.sendAndReceive({
+				id: 1,
+				method: 'run',
+				params: { args: { _: ['status'] } },
+			});
+
+			await conn.sendAndReceive({
+				id: 2,
+				method: 'run',
+				params: { args: { _: ['status'] } },
+			});
+
+			expect(connectionCount).toBe(2);
+		});
+
+		it('throws when daemon closes connection without responding', async () => {
+			await createMockServer((socket) => {
+				// Close immediately without responding
+				socket.end();
+			});
+
+			const conn = new ClientSocketConnection({
+				socketPath,
+				connectTimeout: 2000,
+				responseTimeout: 2000,
+				maxRetries: 0,
+			});
+
+			await expect(
+				conn.sendAndReceive({
+					id: 1,
+					method: 'run',
+					params: { args: { _: ['status'] } },
+				}),
+			).rejects.toThrow(ClientConnectionError);
+		});
+	});
+});


### PR DESCRIPTION
## Summary

Implements the CLI client and argument parsing for issue #7. This is the user-facing entry point that connects to the daemon over a Unix domain socket.

Closes #7

## What's Included

### Source Files
- **`src/client/cli.ts`** — Entry point: `minimist` → zod validation → dispatch to daemon
- **`src/client/session.ts`** — `ClientSession`: connects to daemon socket, sends commands, reads responses
- **`src/client/socketConnection.ts`** — Newline-delimited JSON over UDS, reconnect logic, error framing
- **`src/client/repl.ts`** — Interactive REPL mode (readline-based) for `cypress-cli repl`
- **`src/client/index.ts`** — Updated with re-exports and main entry detection
- **`bin/cypress-cli.js`** — `#!/usr/bin/env node` ESM shim

### Configuration
- **`eslint.config.js`** — ESLint 9 flat config with TypeScript support via `typescript-eslint`
- **`package.json`** — Updated `bin` path to `./bin/cypress-cli.js`, added `bin/` to `files`

### Tests
- **`tests/unit/client/cli.test.ts`** — 27 tests: argument parsing, flag validation, error exit codes, JSON output
- **`tests/unit/client/socketConnection.test.ts`** — 9 tests: framing, split buffers, reconnect, timeout, error handling

## Acceptance Criteria

- [x] `src/client/cli.ts` — entry point, `minimist` → zod validation → dispatch
- [x] `src/client/session.ts` — `ClientSession`: connects to daemon socket, sends commands, reads responses
- [x] `src/client/socketConnection.ts` — newline-delimited JSON over UDS, reconnect logic, error framing
- [x] `src/client/repl.ts` — interactive REPL mode (readline-based) for `cypress-cli repl`
- [x] `bin/cypress-cli` shim — `#!/usr/bin/env node` + ESM loader
- [x] Exit codes: 0 success, 1 command error, 2 connection error, 3 validation error
- [x] `--json` flag outputs machine-readable JSON for all commands
- [x] `--session <id>` flag targets a specific session
- [x] `tests/unit/client/cli.test.ts` — argument parsing, flag validation, error exit codes
- [x] `tests/unit/client/socketConnection.test.ts` — framing, reconnect, timeout

## Verification

```bash
npx tsc --noEmit        # ✅ passes
npx vitest run          # ✅ 196 tests pass (36 new)
npx eslint src/ tests/  # ✅ no errors (3 warnings in pre-existing code)
```
