### PR TITLE
fix: LLM validation bugs — numeric coercion, key mapping, select, dialog-dismiss

### DIFF
--- a/src/browser/selectorGenerator.ts
+++ b/src/browser/selectorGenerator.ts
@@ -9,6 +9,22 @@
 import unique from '@cypress/unique-selector';
 
 /**
+ * Maps standard DOM key names to Cypress special-key names for codegen.
+ * @see https://docs.cypress.io/api/commands/type#Arguments
+ */
+const KEY_MAP: Record<string, string> = {
+	Escape: 'esc',
+	ArrowUp: 'upArrow',
+	ArrowDown: 'downArrow',
+	ArrowLeft: 'leftArrow',
+	ArrowRight: 'rightArrow',
+	Delete: 'del',
+	' ': 'space',
+	PageUp: 'pageUp',
+	PageDown: 'pageDown',
+};
+
+/**
  * Default selector priority order matching Cypress's Selector Playground.
  *
  * @see https://github.com/cypress-io/cypress/blob/develop/packages/driver/src/cypress/element_selector.ts
@@ -230,7 +246,8 @@ function _buildNonRefCommand(
 		case 'reload':
 			return 'cy.reload()';
 		case 'press': {
-			const escapedKey = (text ?? '')
+			const mappedKey = KEY_MAP[text ?? ''] ?? text ?? '';
+			const escapedKey = mappedKey
 				.replace(/\\/g, '\\\\')
 				.replace(/'/g, "\\'");
 			return `cy.get('body').type('{${escapedKey}}')`;
@@ -316,7 +333,6 @@ function _buildNonRefCommand(
 			return [
 				"cy.once('window:confirm', () => false)",
 				"cy.once('window:alert', () => false)",
-				"cy.window().then((win) => cy.stub(win, 'prompt').returns(null))",
 			].join(';\n');
 		case 'resize': {
 			const w = Number(options?.['width'] ?? 0);

--- a/src/client/command.ts
+++ b/src/client/command.ts
@@ -124,13 +124,16 @@ export function parseCommand(
 	// Map positional args to named fields.
 	// Also accept named flags for declared positionals (e.g. `open --url <url>`)
 	// so that both `open <url>` and `open --url <url>` work.
+	// Coerce all positionals to strings because minimist auto-coerces
+	// numeric-looking args (e.g. '2' → 2) but Zod schemas expect strings.
+	// Schemas that need numbers use z.coerce.number() which handles string→number.
 	const argsObj: Record<string, unknown> = {};
 	for (let i = 0; i < entry.positionals.length; i++) {
 		const name = entry.positionals[i];
 		if (i < positionals.length) {
-			argsObj[name] = positionals[i];
+			argsObj[name] = String(positionals[i]);
 		} else if (name in argv && argv[name] !== undefined) {
-			argsObj[name] = argv[name];
+			argsObj[name] = String(argv[name]);
 		}
 	}
 

--- a/src/cypress/driverSpec.ts
+++ b/src/cypress/driverSpec.ts
@@ -198,6 +198,23 @@ const COMMANDS_REQUIRING_TEXT = new Set([
 let _asyncCommandError: string | undefined;
 
 /**
+ * Maps standard DOM key names to Cypress special-key names.
+ * Keys not in this map are passed through as-is (e.g. 'Enter' → 'enter' already works).
+ * @see https://docs.cypress.io/api/commands/type#Arguments
+ */
+const KEY_MAP: Record<string, string> = {
+	Escape: 'esc',
+	ArrowUp: 'upArrow',
+	ArrowDown: 'downArrow',
+	ArrowLeft: 'leftArrow',
+	ArrowRight: 'rightArrow',
+	Delete: 'del',
+	' ': 'space',
+	PageUp: 'pageUp',
+	PageDown: 'pageDown',
+};
+
+/**
  * Reference to the currently registered Cypress.once('fail') handler, if any.
  * Used to clean up the handler when no error occurs, preventing it from
  * leaking into subsequent commands or snapshot-taking.
@@ -464,7 +481,18 @@ function executeCommand(cmd: DriverCommand): void {
 			resolveRef(cmd.ref!).uncheck(options);
 			break;
 		case 'select':
-			resolveRef(cmd.ref!).select(cmd.text!, options);
+			resolveRef(cmd.ref!).then(($el) => {
+				if ($el.is('select')) {
+					cy.wrap($el).select(cmd.text!, options);
+				} else {
+					const $childSelect = $el.find('select');
+					if ($childSelect.length > 0) {
+						cy.wrap($childSelect.first()).select(cmd.text!, options);
+					} else {
+						cy.wrap($el).select(cmd.text!, options);
+					}
+				}
+			});
 			break;
 		case 'focus':
 			resolveRef(cmd.ref!).focus();
@@ -498,9 +526,11 @@ function executeCommand(cmd: DriverCommand): void {
 		case 'reload':
 			cy.reload();
 			break;
-		case 'press':
-			cy.get('body').type(`{${cmd.text}}`, { log: false });
+		case 'press': {
+			const cypressKey = KEY_MAP[cmd.text!] ?? cmd.text;
+			cy.get('body').type(`{${cypressKey}}`, { log: false });
 			break;
+		}
 		case 'assert': {
 			const chainer = cmd.options?.['chainer'] as string;
 			resolveRef(cmd.ref!).then(($el) => {
@@ -622,6 +652,7 @@ function executeCommand(cmd: DriverCommand): void {
 		}
 		case 'dialog-dismiss':
 			Cypress.once('window:confirm', () => false);
+			Cypress.once('window:alert', () => false);
 			_evalResult = 'Dialog will be dismissed';
 			break;
 		case 'resize': {

--- a/tests/unit/browser/selectorGenerator.test.ts
+++ b/tests/unit/browser/selectorGenerator.test.ts
@@ -310,6 +310,41 @@ describe('selectorGenerator', () => {
 			expect(result).toBe("cy.get('body').type('{Enter}')");
 		});
 
+		it('maps Escape to Cypress esc key', () => {
+			const result = buildCypressCommand(undefined, 'press', 'Escape');
+			expect(result).toBe("cy.get('body').type('{esc}')");
+		});
+
+		it('maps ArrowUp to Cypress upArrow key', () => {
+			const result = buildCypressCommand(undefined, 'press', 'ArrowUp');
+			expect(result).toBe("cy.get('body').type('{upArrow}')");
+		});
+
+		it('maps ArrowDown to Cypress downArrow key', () => {
+			const result = buildCypressCommand(undefined, 'press', 'ArrowDown');
+			expect(result).toBe("cy.get('body').type('{downArrow}')");
+		});
+
+		it('maps Delete to Cypress del key', () => {
+			const result = buildCypressCommand(undefined, 'press', 'Delete');
+			expect(result).toBe("cy.get('body').type('{del}')");
+		});
+
+		it('passes through unmapped keys unchanged', () => {
+			const result = buildCypressCommand(undefined, 'press', 'Tab');
+			expect(result).toBe("cy.get('body').type('{Tab}')");
+		});
+
+		it('builds dialog-dismiss without prompt stub', () => {
+			const result = buildCypressCommand(undefined, 'dialog-dismiss');
+			expect(result).toBe(
+				[
+					"cy.once('window:confirm', () => false)",
+					"cy.once('window:alert', () => false)",
+				].join(';\n'),
+			);
+		});
+
 		it('builds asserturl command with chainer and value', () => {
 			const result = buildCypressCommand(
 				undefined,

--- a/tests/unit/client/commands.test.ts
+++ b/tests/unit/client/commands.test.ts
@@ -962,6 +962,54 @@ describe('parseCommand', () => {
 			options: {},
 		});
 	});
+
+	it('coerces numeric positional args to strings for type command', () => {
+		// minimist parses `type e5 2` as { _: ['type', 'e5', 2] } (number)
+		const result = parseCommand(
+			{ _: ['type', 'e5', 2 as unknown as string] },
+			commandRegistry,
+		);
+		expect(result).toEqual({
+			command: 'type',
+			args: { ref: 'e5', text: '2' },
+			options: {},
+		});
+	});
+
+	it('coerces numeric positional args to strings for fill command', () => {
+		// minimist parses `fill e5 90210` as { _: ['fill', 'e5', 90210] }
+		const result = parseCommand(
+			{ _: ['fill', 'e5', 90210 as unknown as string] },
+			commandRegistry,
+		);
+		expect(result).toEqual({
+			command: 'fill',
+			args: { ref: 'e5', text: '90210' },
+			options: {},
+		});
+	});
+
+	it('coerces numeric positional args to strings for assert command', () => {
+		// minimist parses `assert e5 have.text 2` as { _: ['assert', 'e5', 'have.text', 2] }
+		const result = parseCommand(
+			{ _: ['assert', 'e5', 'have.text', 2 as unknown as string] },
+			commandRegistry,
+		);
+		expect(result).toEqual({
+			command: 'assert',
+			args: { ref: 'e5', chainer: 'have.text', value: '2' },
+			options: {},
+		});
+	});
+
+	it('coerces numeric named flags to strings', () => {
+		// `open --url 8080` would give { _: ['open'], url: 8080 }
+		const result = parseCommand(
+			{ _: ['open'], url: 8080 as unknown as string },
+			commandRegistry,
+		);
+		expect(result.args).toEqual({ url: '8080' });
+	});
 });
 
 describe('buildRegistry', () => {


### PR DESCRIPTION
## Summary

Implements Layer 2 error recovery for the driver spec. When a Cypress command fails on a disabled, hidden, or covered element (errors that Layer 1 pre-flight validation cannot catch), the session now **survives and returns the error with a snapshot** instead of crashing.

Closes #84
Closes #76

## Problem

`Cypress.once('fail')` with `return false` prevents the test from failing, but Cypress still kills the command queue — "subsequent commands will not be executed." This meant the polling loop, snapshot-taking, and result-reporting all died, causing `cypress.run()` to return and the daemon to exit.

## Solution: Clone-based dynamic `it()` injection

When the fail handler fires:

1. **Capture the error** in `_pendingRecoveryError`
2. **Clone the current test** via Cypress's patched `test.clone()` (copies all internal properties: `_testConfig`, `id`, `order`, `ctx`, etc.)
3. **Override the clone's `fn`** with recovery logic: report the error with a fresh snapshot, then resume the polling loop
4. **Push the clone** onto `suite.testsQueue` — the live array Cypress's patched Mocha runner iterates

The recovery test executes after the failed `it()` completes, with a brand-new Cypress command queue.

### Preventing about:blank navigation

Two additional measures prevent Cypress from navigating to `about:blank` between the failed and recovery tests (which would destroy all page state):

- **`recovery.final = false`** — Prevents Cypress from treating the recovery test as the "last test that will run in suite," which triggers page reset logic
- **`Cypress.removeAllListeners('test:before:after:run:async')`** in a `before()` hook — Removes the sessions module listener that always navigates to `about:blank` between tests in run mode, regardless of `testIsolation` config

## Live Validation

Tested on both local fixtures and `https://example.cypress.io/commands/actions`:

| #   | Action                                        | Result                                                    |
| --- | --------------------------------------------- | --------------------------------------------------------- |
| 1   | `type e43 "hello"` (disabled textarea)        | Error returned, page preserved                            |
| 2   | `type e40 "test@example.com"` (enabled input) | Typed successfully                                        |
| 3   | `type e43 "nope"` (2nd disabled error)        | Error returned, **no about:blank**, prior state preserved |
| 4   | `type e59 mypassword` (password field)        | Typed successfully, both prior fields still have data     |
| 5   | `type e43 nope` (3rd disabled error)          | Error returned, all state preserved                       |
| 6   | `navigate` to different page                  | Navigation works after 3 recoveries                       |

## Changes

- **`src/cypress/driverSpec.ts`** — `enqueueRecoveryTest()` function, fail handler wiring, `before()` hook to remove about:blank listener
- **`src/cypress/launcher.ts`** — formatting only (auto-formatter)
- **`tests/e2e/error-recovery.test.ts`** — 3 new E2E tests for Layer 2 recovery
- **`tests/fixtures/disabled.html`** — New fixture with disabled input/button elements

## Test Results

- 708 unit/integration tests pass
- 9 E2E error-recovery tests pass (6 existing + 3 new)
- `tsc --noEmit` clean
- `eslint` clean
