### PR TITLE
fix: restore Playwright ref caching for stable element refs

### DIFF
--- a/src/browser/snapshotManager.ts
+++ b/src/browser/snapshotManager.ts
@@ -32,10 +32,10 @@ export interface AriaSnapshotApi {
  * `renderAriaTree()` can produce incremental diffs.  Starts as `undefined`
  * (first snapshot in a session returns a full tree).
  *
- * Keyed to `_lastWindow` so that a full-page navigation (which gives
- * Cypress a new AUT `Window` and resets the IIFE's internal ref counter)
- * automatically discards the stale previous snapshot instead of producing
- * incorrect `[unchanged]` markers from ref collisions.
+ * Keyed to `_lastWindow` so that a full-page navigation (which creates a
+ * new AUT `Window` and re-injects the IIFE, resetting the ref counter and
+ * clearing element caches) automatically discards the stale previous
+ * snapshot instead of producing incorrect `[unchanged]` markers.
  */
 let _previousSnapshot: unknown;
 

--- a/src/injected/ariaSnapshot.ts
+++ b/src/injected/ariaSnapshot.ts
@@ -36,8 +36,7 @@ export type AriaSnapshot = {
   iframeRefs: string[];
 };
 
-// REMOVED: AriaRef — ref caching on DOM elements removed; refs are now assigned fresh per snapshot.
-type _AriaRef = {
+type AriaRef = {
   role: string;
   name: string;
   ref: string;
@@ -86,9 +85,6 @@ function toInternalOptions(options: AriaTreeOptions): InternalOptions {
 }
 
 export function generateAriaTree(rootElement: Element, publicOptions: AriaTreeOptions): AriaSnapshot {
-  // MODIFIED: Reset ref counter so each snapshot gets clean e1-eN refs,
-  // preventing unbounded growth in long sessions.
-  lastRef = 0;
   const options = toInternalOptions(publicOptions);
   const visited = new Set<Node>();
 
@@ -234,8 +230,13 @@ function computeAriaRef(ariaNode: AriaNode, options: InternalOptions) {
   if (options.refs === 'interactable' && (!ariaNode.box.visible || !ariaNode.receivesPointerEvents))
     return;
 
-  // MODIFIED: Always assign a fresh ref since the counter resets per snapshot.
-  ariaNode.ref = (options.refPrefix ?? '') + 'e' + (++lastRef);
+  const element = ariaNodeElement(ariaNode);
+  let ariaRef = (element as any)._ariaRef as AriaRef | undefined;
+  if (!ariaRef || ariaRef.role !== ariaNode.role || ariaRef.name !== ariaNode.name) {
+    ariaRef = { role: ariaNode.role, name: ariaNode.name, ref: (options.refPrefix ?? '') + 'e' + (++lastRef) };
+    (element as any)._ariaRef = ariaRef;
+  }
+  ariaNode.ref = ariaRef.ref;
 }
 
 function toAriaNode(element: Element, options: InternalOptions): AriaNode | null {

--- a/tests/unit/injected/ariaSnapshot.test.ts
+++ b/tests/unit/injected/ariaSnapshot.test.ts
@@ -102,6 +102,49 @@ describe('generateAriaTree + renderAriaTree', () => {
     expect(snapshot.elements.size).toBeGreaterThan(0);
   });
 
+  it('keeps stable refs for unchanged elements across snapshots', () => {
+    document.body.innerHTML = '<a href="#">Link</a><button>Btn</button>';
+    const snap1 = generateAriaTree(document.body, { mode: 'ai' });
+    const yaml1 = renderAriaTree(snap1, { mode: 'ai' });
+    const linkRef1 = yaml1.match(/link "Link" \[ref=(e\d+)\]/)![1];
+    const btnRef1 = yaml1.match(/button "Btn" \[ref=(e\d+)\]/)![1];
+
+    // Add a new element — existing refs should stay the same
+    const extra = document.createElement('button');
+    extra.textContent = 'New';
+    document.body.appendChild(extra);
+
+    const snap2 = generateAriaTree(document.body, { mode: 'ai' });
+    const yaml2 = renderAriaTree(snap2, { mode: 'ai' });
+    const linkRef2 = yaml2.match(/link "Link" \[ref=(e\d+)\]/)![1];
+    const btnRef2 = yaml2.match(/button "Btn" \[ref=(e\d+)\]/)![1];
+
+    expect(linkRef2).toBe(linkRef1);
+    expect(btnRef2).toBe(btnRef1);
+
+    // The new element should have a different ref
+    const newRef = yaml2.match(/button "New" \[ref=(e\d+)\]/)![1];
+    expect(newRef).not.toBe(linkRef1);
+    expect(newRef).not.toBe(btnRef1);
+  });
+
+  it('assigns a new ref when element name changes', () => {
+    document.body.innerHTML = '<button>Original</button>';
+    const snap1 = generateAriaTree(document.body, { mode: 'ai' });
+    const yaml1 = renderAriaTree(snap1, { mode: 'ai' });
+    const ref1 = yaml1.match(/button "Original" \[ref=(e\d+)\]/)![1];
+
+    // Change the button's text (accessible name)
+    document.querySelector('button')!.textContent = 'Changed';
+
+    const snap2 = generateAriaTree(document.body, { mode: 'ai' });
+    const yaml2 = renderAriaTree(snap2, { mode: 'ai' });
+    const ref2 = yaml2.match(/button "Changed" \[ref=(e\d+)\]/)![1];
+
+    // Name changed, so the element gets a new ref
+    expect(ref2).not.toBe(ref1);
+  });
+
   it('includes url prop for links', () => {
     document.body.innerHTML = '<a href="/about">About</a>';
     const snapshot = generateAriaTree(document.body, { mode: 'ai' });
@@ -213,36 +256,32 @@ describe('generateAriaTree + renderAriaTree', () => {
     expect(yaml).toContain('[unchanged]');
   });
 
-  it('resets ref counter on each generateAriaTree call', () => {
+  it('returns same refs for unchanged elements on repeated calls', () => {
     document.body.innerHTML = '<a href="#">Link</a><button>Btn</button>';
     const snap1 = generateAriaTree(document.body, { mode: 'ai' });
     const refs1 = [...snap1.elements.keys()];
 
-    // Second call on the same DOM should produce the same low-numbered refs
+    // Second call on the same DOM should produce the same refs (cached on elements)
     const snap2 = generateAriaTree(document.body, { mode: 'ai' });
     const refs2 = [...snap2.elements.keys()];
 
     expect(refs1).toEqual(refs2);
-    // All refs should be low-numbered (e1, e2, etc.)
-    for (const ref of refs1) {
-      const num = parseInt(ref.replace(/^e/, ''), 10);
-      expect(num).toBeLessThanOrEqual(refs1.length);
-    }
   });
 
-  it('produces consistent low-numbered refs across many snapshots', () => {
+  it('keeps stable refs across many snapshots without reassigning', () => {
     document.body.innerHTML = '<button>A</button><button>B</button><button>C</button>';
+    const firstSnap = generateAriaTree(document.body, { mode: 'ai' });
+    const firstRefs = [...firstSnap.elements.keys()];
+
     // Simulate many sequential snapshots (like a long REPL session)
     for (let i = 0; i < 50; i++) {
       generateAriaTree(document.body, { mode: 'ai' });
     }
-    const snap = generateAriaTree(document.body, { mode: 'ai' });
-    const refs = [...snap.elements.keys()];
-    // After 50+ calls, refs should still be low-numbered, not e150+
-    for (const ref of refs) {
-      const num = parseInt(ref.replace(/^e/, ''), 10);
-      expect(num).toBeLessThanOrEqual(refs.length);
-    }
+    const lastSnap = generateAriaTree(document.body, { mode: 'ai' });
+    const lastRefs = [...lastSnap.elements.keys()];
+
+    // Refs should be identical to the first snapshot since elements haven't changed
+    expect(lastRefs).toEqual(firstRefs);
   });
 });
 


### PR DESCRIPTION
Closes #101

## Summary

Restore Playwright's original AriaRef caching mechanism in `computeAriaRef()` so element refs are stable across snapshots.

## What changed

**src/injected/ariaSnapshot.ts:**
- Restored `AriaRef` type (was prefixed with `_` and unused)
- Removed `lastRef = 0` reset from `generateAriaTree()` — counter now increments monotonically
- Restored ref caching on DOM elements via `element._ariaRef` in `computeAriaRef()` — same element keeps its ref across snapshots unless its role or name changes

**src/browser/snapshotManager.ts:**
- Updated comment to reflect new caching behavior

**tests/unit/injected/ariaSnapshot.test.ts:**
- Added "keeps stable refs for unchanged elements across snapshots" test
- Added "assigns a new ref when element name changes" test
- Replaced "resets ref counter" and "low-numbered refs" tests with "returns same refs" and "keeps stable refs across many snapshots" tests

## Live Validation

Opened session against `https://example.cypress.io/commands/actions`:
1. Initial snapshot: `textbox "Email address" [ref=e40]`
2. After `type e40 'test@test.com'`: ref still `e40`
3. After another `snapshot`: ref still `e40`
4. `assert e40 have.value 'test@test.com'` — passes, ref resolves correctly
