### PR TITLE
feat: add localStorage and sessionStorage commands

### DIFF
--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -117,13 +117,23 @@ or require a running Cypress session.
 
 ### Storage
 
-| Command         | Syntax                                                                                           | Description                                          |
-| --------------- | ------------------------------------------------------------------------------------------------ | ---------------------------------------------------- |
-| `cookie-list`   | `cypress-cli cookie-list [--domain domain]`                                                      | List cookies, optionally filtered by domain          |
-| `cookie-get`    | `cypress-cli cookie-get <name>`                                                                  | Get a cookie by name (`cy.getCookie()`)              |
-| `cookie-set`    | `cypress-cli cookie-set <name> <value> [--domain d] [--httpOnly] [--secure] [--path p]`         | Set a cookie (`cy.setCookie()`)                      |
-| `cookie-delete` | `cypress-cli cookie-delete <name>`                                                               | Delete a cookie by name (`cy.clearCookie()`)         |
-| `cookie-clear`  | `cypress-cli cookie-clear`                                                                       | Clear all cookies (`cy.clearCookies()`)              |
+| Command                 | Syntax                                                                                           | Description                                                    |
+| ----------------------- | ------------------------------------------------------------------------------------------------ | -------------------------------------------------------------- |
+| `cookie-list`           | `cypress-cli cookie-list [--domain domain]`                                                      | List cookies, optionally filtered by domain                    |
+| `cookie-get`            | `cypress-cli cookie-get <name>`                                                                  | Get a cookie by name (`cy.getCookie()`)                        |
+| `cookie-set`            | `cypress-cli cookie-set <name> <value> [--domain d] [--httpOnly] [--secure] [--path p]`         | Set a cookie (`cy.setCookie()`)                                |
+| `cookie-delete`         | `cypress-cli cookie-delete <name>`                                                               | Delete a cookie by name (`cy.clearCookie()`)                   |
+| `cookie-clear`          | `cypress-cli cookie-clear`                                                                       | Clear all cookies (`cy.clearCookies()`)                        |
+| `localstorage-list`     | `cypress-cli localstorage-list`                                                                  | List all localStorage entries as JSON                          |
+| `localstorage-get`      | `cypress-cli localstorage-get <key>`                                                             | Get a localStorage value by key                                |
+| `localstorage-set`      | `cypress-cli localstorage-set <key> <value>`                                                     | Set a localStorage key-value pair                              |
+| `localstorage-delete`   | `cypress-cli localstorage-delete <key>`                                                          | Delete a localStorage entry by key                             |
+| `localstorage-clear`    | `cypress-cli localstorage-clear`                                                                 | Clear all localStorage entries (`cy.clearLocalStorage()`)      |
+| `sessionstorage-list`   | `cypress-cli sessionstorage-list`                                                                | List all sessionStorage entries as JSON                        |
+| `sessionstorage-get`    | `cypress-cli sessionstorage-get <key>`                                                           | Get a sessionStorage value by key                              |
+| `sessionstorage-set`    | `cypress-cli sessionstorage-set <key> <value>`                                                   | Set a sessionStorage key-value pair                            |
+| `sessionstorage-delete` | `cypress-cli sessionstorage-delete <key>`                                                        | Delete a sessionStorage entry by key                           |
+| `sessionstorage-clear`  | `cypress-cli sessionstorage-clear`                                                               | Clear all sessionStorage entries                               |
 
 ## Command Schemas (zod)
 

--- a/src/client/commands.ts
+++ b/src/client/commands.ts
@@ -643,6 +643,108 @@ export const stateLoad = declareCommand({
 });
 
 // ---------------------------------------------------------------------------
+// localStorage commands
+// ---------------------------------------------------------------------------
+
+export const localstorageList = declareCommand({
+	name: 'localstorage-list',
+	category: 'storage',
+	description: 'List all localStorage entries as JSON',
+	args: z.object({}),
+	options: z.object({}),
+});
+
+export const localstorageGet = declareCommand({
+	name: 'localstorage-get',
+	category: 'storage',
+	description: 'Get a localStorage value by key',
+	args: z.object({
+		key: z.string().describe('localStorage key'),
+	}),
+	options: z.object({}),
+});
+
+export const localstorageSet = declareCommand({
+	name: 'localstorage-set',
+	category: 'storage',
+	description: 'Set a localStorage key-value pair',
+	args: z.object({
+		key: z.string().describe('localStorage key'),
+		value: z.string().describe('Value to store'),
+	}),
+	options: z.object({}),
+});
+
+export const localstorageDelete = declareCommand({
+	name: 'localstorage-delete',
+	category: 'storage',
+	description: 'Delete a localStorage entry by key',
+	args: z.object({
+		key: z.string().describe('localStorage key'),
+	}),
+	options: z.object({}),
+});
+
+export const localstorageClear = declareCommand({
+	name: 'localstorage-clear',
+	category: 'storage',
+	description: 'Clear all localStorage entries',
+	args: z.object({}),
+	options: z.object({}),
+});
+
+// ---------------------------------------------------------------------------
+// sessionStorage commands
+// ---------------------------------------------------------------------------
+
+export const sessionstorageList = declareCommand({
+	name: 'sessionstorage-list',
+	category: 'storage',
+	description: 'List all sessionStorage entries as JSON',
+	args: z.object({}),
+	options: z.object({}),
+});
+
+export const sessionstorageGet = declareCommand({
+	name: 'sessionstorage-get',
+	category: 'storage',
+	description: 'Get a sessionStorage value by key',
+	args: z.object({
+		key: z.string().describe('sessionStorage key'),
+	}),
+	options: z.object({}),
+});
+
+export const sessionstorageSet = declareCommand({
+	name: 'sessionstorage-set',
+	category: 'storage',
+	description: 'Set a sessionStorage key-value pair',
+	args: z.object({
+		key: z.string().describe('sessionStorage key'),
+		value: z.string().describe('Value to store'),
+	}),
+	options: z.object({}),
+});
+
+export const sessionstorageDelete = declareCommand({
+	name: 'sessionstorage-delete',
+	category: 'storage',
+	description: 'Delete a sessionStorage entry by key',
+	args: z.object({
+		key: z.string().describe('sessionStorage key'),
+	}),
+	options: z.object({}),
+});
+
+export const sessionstorageClear = declareCommand({
+	name: 'sessionstorage-clear',
+	category: 'storage',
+	description: 'Clear all sessionStorage entries',
+	args: z.object({}),
+	options: z.object({}),
+});
+
+// ---------------------------------------------------------------------------
 // Screenshot command
 // ---------------------------------------------------------------------------
 
@@ -751,6 +853,16 @@ export const allCommands = [
 	cookieClear,
 	stateSave,
 	stateLoad,
+	localstorageList,
+	localstorageGet,
+	localstorageSet,
+	localstorageDelete,
+	localstorageClear,
+	sessionstorageList,
+	sessionstorageGet,
+	sessionstorageSet,
+	sessionstorageDelete,
+	sessionstorageClear,
 	screenshot,
 	drag,
 	upload,
@@ -878,6 +990,46 @@ export function buildRegistry(): ReadonlyMap<string, CommandRegistryEntry> {
 	registry.set('state-load', {
 		schema: stateLoad,
 		positionals: ['filename'],
+	});
+	registry.set('localstorage-list', {
+		schema: localstorageList,
+		positionals: [],
+	});
+	registry.set('localstorage-get', {
+		schema: localstorageGet,
+		positionals: ['key'],
+	});
+	registry.set('localstorage-set', {
+		schema: localstorageSet,
+		positionals: ['key', 'value'],
+	});
+	registry.set('localstorage-delete', {
+		schema: localstorageDelete,
+		positionals: ['key'],
+	});
+	registry.set('localstorage-clear', {
+		schema: localstorageClear,
+		positionals: [],
+	});
+	registry.set('sessionstorage-list', {
+		schema: sessionstorageList,
+		positionals: [],
+	});
+	registry.set('sessionstorage-get', {
+		schema: sessionstorageGet,
+		positionals: ['key'],
+	});
+	registry.set('sessionstorage-set', {
+		schema: sessionstorageSet,
+		positionals: ['key', 'value'],
+	});
+	registry.set('sessionstorage-delete', {
+		schema: sessionstorageDelete,
+		positionals: ['key'],
+	});
+	registry.set('sessionstorage-clear', {
+		schema: sessionstorageClear,
+		positionals: [],
 	});
 
 	// Screenshot

--- a/src/cypress/driverSpec.ts
+++ b/src/cypress/driverSpec.ts
@@ -107,6 +107,16 @@ const STRUCTURED_DATA_ONLY_COMMANDS = new Set([
 	'cookie-set',
 	'cookie-delete',
 	'cookie-clear',
+	'localstorage-list',
+	'localstorage-get',
+	'localstorage-set',
+	'localstorage-delete',
+	'localstorage-clear',
+	'sessionstorage-list',
+	'sessionstorage-get',
+	'sessionstorage-set',
+	'sessionstorage-delete',
+	'sessionstorage-clear',
 	'state-save',
 	'state-load',
 ]);
@@ -782,6 +792,114 @@ function executeCommand(cmd: DriverCommand): void {
 						cleared: cookies.length,
 					});
 				});
+			});
+			break;
+		}
+		case 'localstorage-list': {
+			cy.window({ log: false }).then((win: Window) => {
+				const entries: Record<string, string> = {};
+				for (let i = 0; i < win.localStorage.length; i++) {
+					const key = win.localStorage.key(i);
+					if (key !== null) {
+						entries[key] = win.localStorage.getItem(key) ?? '';
+					}
+				}
+				_evalResult = JSON.stringify(entries);
+			});
+			break;
+		}
+		case 'localstorage-get': {
+			const key = cmd.text!;
+			cy.window({ log: false }).then((win: Window) => {
+				const value = win.localStorage.getItem(key);
+				if (value === null) {
+					_asyncCommandError = `localStorage key "${key}" not found.`;
+					return;
+				}
+				_evalResult = JSON.stringify({ key, value });
+			});
+			break;
+		}
+		case 'localstorage-set': {
+			const key = cmd.text!;
+			const value = String(cmd.options?.['value'] ?? '');
+			cy.window({ log: false }).then((win: Window) => {
+				win.localStorage.setItem(key, value);
+				_evalResult = JSON.stringify({ key, value });
+			});
+			break;
+		}
+		case 'localstorage-delete': {
+			const key = cmd.text!;
+			cy.window({ log: false }).then((win: Window) => {
+				if (win.localStorage.getItem(key) === null) {
+					_asyncCommandError = `localStorage key "${key}" not found.`;
+					return;
+				}
+				win.localStorage.removeItem(key);
+				_evalResult = JSON.stringify({ key, deleted: true });
+			});
+			break;
+		}
+		case 'localstorage-clear': {
+			cy.window({ log: false }).then((win: Window) => {
+				const count = win.localStorage.length;
+				win.localStorage.clear();
+				_evalResult = JSON.stringify({ cleared: count });
+			});
+			break;
+		}
+		case 'sessionstorage-list': {
+			cy.window({ log: false }).then((win: Window) => {
+				const entries: Record<string, string> = {};
+				for (let i = 0; i < win.sessionStorage.length; i++) {
+					const key = win.sessionStorage.key(i);
+					if (key !== null) {
+						entries[key] = win.sessionStorage.getItem(key) ?? '';
+					}
+				}
+				_evalResult = JSON.stringify(entries);
+			});
+			break;
+		}
+		case 'sessionstorage-get': {
+			const key = cmd.text!;
+			cy.window({ log: false }).then((win: Window) => {
+				const value = win.sessionStorage.getItem(key);
+				if (value === null) {
+					_asyncCommandError = `sessionStorage key "${key}" not found.`;
+					return;
+				}
+				_evalResult = JSON.stringify({ key, value });
+			});
+			break;
+		}
+		case 'sessionstorage-set': {
+			const key = cmd.text!;
+			const value = String(cmd.options?.['value'] ?? '');
+			cy.window({ log: false }).then((win: Window) => {
+				win.sessionStorage.setItem(key, value);
+				_evalResult = JSON.stringify({ key, value });
+			});
+			break;
+		}
+		case 'sessionstorage-delete': {
+			const key = cmd.text!;
+			cy.window({ log: false }).then((win: Window) => {
+				if (win.sessionStorage.getItem(key) === null) {
+					_asyncCommandError = `sessionStorage key "${key}" not found.`;
+					return;
+				}
+				win.sessionStorage.removeItem(key);
+				_evalResult = JSON.stringify({ key, deleted: true });
+			});
+			break;
+		}
+		case 'sessionstorage-clear': {
+			cy.window({ log: false }).then((win: Window) => {
+				const count = win.sessionStorage.length;
+				win.sessionStorage.clear();
+				_evalResult = JSON.stringify({ cleared: count });
 			});
 			break;
 		}

--- a/src/daemon/commandBuilder.ts
+++ b/src/daemon/commandBuilder.ts
@@ -199,6 +199,10 @@ export function buildQueuedCommand(
 		case 'network':
 		case 'cookie-list':
 		case 'cookie-clear':
+		case 'localstorage-list':
+		case 'localstorage-clear':
+		case 'sessionstorage-list':
+		case 'sessionstorage-clear':
 			return withOptions({ id, action }, options);
 		case 'state-save':
 			return withOptions(
@@ -256,6 +260,10 @@ export function buildQueuedCommand(
 			);
 		case 'cookie-get':
 		case 'cookie-delete':
+		case 'localstorage-get':
+		case 'localstorage-delete':
+		case 'sessionstorage-get':
+		case 'sessionstorage-delete':
 			return withOptions(
 				{
 					id,
@@ -267,6 +275,8 @@ export function buildQueuedCommand(
 				options,
 			);
 		case 'cookie-set':
+		case 'localstorage-set':
+		case 'sessionstorage-set':
 			return withOptions(
 				{
 					id,

--- a/tests/unit/client/commands.test.ts
+++ b/tests/unit/client/commands.test.ts
@@ -60,6 +60,16 @@ import {
 	eval_,
 	stateSave,
 	stateLoad,
+	localstorageList,
+	localstorageGet,
+	localstorageSet,
+	localstorageDelete,
+	localstorageClear,
+	sessionstorageList,
+	sessionstorageGet,
+	sessionstorageSet,
+	sessionstorageDelete,
+	sessionstorageClear,
 } from '../../../src/client/commands.js';
 import { z } from 'zod';
 
@@ -97,12 +107,12 @@ describe('declareCommand', () => {
 });
 
 describe('command schemas', () => {
-	it('defines all 51 commands', () => {
-		expect(allCommands).toHaveLength(51);
+	it('defines all 61 commands', () => {
+		expect(allCommands).toHaveLength(61);
 	});
 
 	it('registers all commands plus aliases in the registry', () => {
-		expect(commandRegistry.size).toBe(55);
+		expect(commandRegistry.size).toBe(65);
 	});
 
 	describe('categories', () => {
@@ -475,6 +485,84 @@ describe('command schemas', () => {
 		it('cookie-clear requires no args or options', () => {
 			expect(cookieClear.args.safeParse({})).toMatchObject({ success: true });
 			expect(cookieClear.options.safeParse({})).toMatchObject({ success: true });
+		});
+
+		it('localstorage-list requires no args', () => {
+			expect(localstorageList.args.safeParse({})).toMatchObject({
+				success: true,
+			});
+		});
+
+		it('localstorage-get requires a key', () => {
+			expect(
+				localstorageGet.args.safeParse({ key: 'token' }),
+			).toMatchObject({ success: true });
+			expect(localstorageGet.args.safeParse({})).toMatchObject({
+				success: false,
+			});
+		});
+
+		it('localstorage-set requires key and value', () => {
+			expect(
+				localstorageSet.args.safeParse({ key: 'token', value: 'abc' }),
+			).toMatchObject({ success: true });
+			expect(
+				localstorageSet.args.safeParse({ key: 'token' }),
+			).toMatchObject({ success: false });
+		});
+
+		it('localstorage-delete requires a key', () => {
+			expect(
+				localstorageDelete.args.safeParse({ key: 'token' }),
+			).toMatchObject({ success: true });
+			expect(localstorageDelete.args.safeParse({})).toMatchObject({
+				success: false,
+			});
+		});
+
+		it('localstorage-clear requires no args', () => {
+			expect(localstorageClear.args.safeParse({})).toMatchObject({
+				success: true,
+			});
+		});
+
+		it('sessionstorage-list requires no args', () => {
+			expect(sessionstorageList.args.safeParse({})).toMatchObject({
+				success: true,
+			});
+		});
+
+		it('sessionstorage-get requires a key', () => {
+			expect(
+				sessionstorageGet.args.safeParse({ key: 'sid' }),
+			).toMatchObject({ success: true });
+			expect(sessionstorageGet.args.safeParse({})).toMatchObject({
+				success: false,
+			});
+		});
+
+		it('sessionstorage-set requires key and value', () => {
+			expect(
+				sessionstorageSet.args.safeParse({ key: 'sid', value: 'x' }),
+			).toMatchObject({ success: true });
+			expect(
+				sessionstorageSet.args.safeParse({ key: 'sid' }),
+			).toMatchObject({ success: false });
+		});
+
+		it('sessionstorage-delete requires a key', () => {
+			expect(
+				sessionstorageDelete.args.safeParse({ key: 'sid' }),
+			).toMatchObject({ success: true });
+			expect(sessionstorageDelete.args.safeParse({})).toMatchObject({
+				success: false,
+			});
+		});
+
+		it('sessionstorage-clear requires no args', () => {
+			expect(sessionstorageClear.args.safeParse({})).toMatchObject({
+				success: true,
+			});
 		});
 
 		it('fill requires ref and text', () => {
@@ -1068,6 +1156,126 @@ describe('parseCommand', () => {
 		const result = parseCommand({ _: ['cookie-clear'] }, commandRegistry);
 		expect(result).toEqual({
 			command: 'cookie-clear',
+			args: {},
+			options: {},
+		});
+	});
+
+	it("parses 'localstorage-list' correctly", () => {
+		const result = parseCommand(
+			{ _: ['localstorage-list'] },
+			commandRegistry,
+		);
+		expect(result).toEqual({
+			command: 'localstorage-list',
+			args: {},
+			options: {},
+		});
+	});
+
+	it("parses 'localstorage-get token' correctly", () => {
+		const result = parseCommand(
+			{ _: ['localstorage-get', 'token'] },
+			commandRegistry,
+		);
+		expect(result).toEqual({
+			command: 'localstorage-get',
+			args: { key: 'token' },
+			options: {},
+		});
+	});
+
+	it("parses 'localstorage-set token abc123' correctly", () => {
+		const result = parseCommand(
+			{ _: ['localstorage-set', 'token', 'abc123'] },
+			commandRegistry,
+		);
+		expect(result).toEqual({
+			command: 'localstorage-set',
+			args: { key: 'token', value: 'abc123' },
+			options: {},
+		});
+	});
+
+	it("parses 'localstorage-delete token' correctly", () => {
+		const result = parseCommand(
+			{ _: ['localstorage-delete', 'token'] },
+			commandRegistry,
+		);
+		expect(result).toEqual({
+			command: 'localstorage-delete',
+			args: { key: 'token' },
+			options: {},
+		});
+	});
+
+	it("parses 'localstorage-clear' correctly", () => {
+		const result = parseCommand(
+			{ _: ['localstorage-clear'] },
+			commandRegistry,
+		);
+		expect(result).toEqual({
+			command: 'localstorage-clear',
+			args: {},
+			options: {},
+		});
+	});
+
+	it("parses 'sessionstorage-list' correctly", () => {
+		const result = parseCommand(
+			{ _: ['sessionstorage-list'] },
+			commandRegistry,
+		);
+		expect(result).toEqual({
+			command: 'sessionstorage-list',
+			args: {},
+			options: {},
+		});
+	});
+
+	it("parses 'sessionstorage-get sid' correctly", () => {
+		const result = parseCommand(
+			{ _: ['sessionstorage-get', 'sid'] },
+			commandRegistry,
+		);
+		expect(result).toEqual({
+			command: 'sessionstorage-get',
+			args: { key: 'sid' },
+			options: {},
+		});
+	});
+
+	it("parses 'sessionstorage-set sid xyz' correctly", () => {
+		const result = parseCommand(
+			{ _: ['sessionstorage-set', 'sid', 'xyz'] },
+			commandRegistry,
+		);
+		expect(result).toEqual({
+			command: 'sessionstorage-set',
+			args: { key: 'sid', value: 'xyz' },
+			options: {},
+		});
+	});
+
+	it("parses 'sessionstorage-delete sid' correctly", () => {
+		const result = parseCommand(
+			{ _: ['sessionstorage-delete', 'sid'] },
+			commandRegistry,
+		);
+		expect(result).toEqual({
+			command: 'sessionstorage-delete',
+			args: { key: 'sid' },
+			options: {},
+		});
+	});
+
+	it("parses 'sessionstorage-clear' correctly", () => {
+		const result = parseCommand(
+			{ _: ['sessionstorage-clear'] },
+			commandRegistry,
+		);
+		expect(result).toEqual({
+			command: 'sessionstorage-clear',
 			args: {},
 			options: {},
 		});

--- a/tests/unit/daemon/buildQueuedCommand.test.ts
+++ b/tests/unit/daemon/buildQueuedCommand.test.ts
@@ -53,8 +53,12 @@ describe('buildQueuedCommand', () => {
 			'cookie-clear',
 			'cookie-list',
 			'forward',
+			'localstorage-clear',
+			'localstorage-list',
 			'network',
 			'reload',
+			'sessionstorage-clear',
+			'sessionstorage-list',
 			'snapshot',
 		] as const;
 
@@ -294,6 +298,50 @@ describe('buildQueuedCommand', () => {
 			id: 23,
 			action: 'cookie-delete',
 			text: 'session',
+		});
+	});
+
+	it('maps storage commands to text and option payloads', () => {
+		expect(buildQueuedCommand(28, makeArgs('localstorage-get', ['token']))).toEqual({
+			id: 28,
+			action: 'localstorage-get',
+			text: 'token',
+		});
+
+		expect(
+			buildQueuedCommand(29, makeArgs('localstorage-set', ['token', 'abc123'])),
+		).toEqual({
+			id: 29,
+			action: 'localstorage-set',
+			text: 'token',
+			options: { value: 'abc123' },
+		});
+
+		expect(buildQueuedCommand(30, makeArgs('localstorage-delete', ['token']))).toEqual({
+			id: 30,
+			action: 'localstorage-delete',
+			text: 'token',
+		});
+
+		expect(buildQueuedCommand(31, makeArgs('sessionstorage-get', ['sid']))).toEqual({
+			id: 31,
+			action: 'sessionstorage-get',
+			text: 'sid',
+		});
+
+		expect(
+			buildQueuedCommand(32, makeArgs('sessionstorage-set', ['sid', 'xyz'])),
+		).toEqual({
+			id: 32,
+			action: 'sessionstorage-set',
+			text: 'sid',
+			options: { value: 'xyz' },
+		});
+
+		expect(buildQueuedCommand(33, makeArgs('sessionstorage-delete', ['sid']))).toEqual({
+			id: 33,
+			action: 'sessionstorage-delete',
+			text: 'sid',
 		});
 	});
 


### PR DESCRIPTION
Closes #57

## Summary

Adds 10 new storage commands mirroring the existing cookie command pattern:

| Command | Description |
|---|---|
| `localstorage-list` | List all localStorage key/value pairs |
| `localstorage-get <key>` | Get a localStorage value by key |
| `localstorage-set <key> <value>` | Set a localStorage key/value pair |
| `localstorage-delete <key>` | Delete a localStorage key |
| `localstorage-clear` | Clear all localStorage |
| `sessionstorage-list` | List all sessionStorage key/value pairs |
| `sessionstorage-get <key>` | Get a sessionStorage value by key |
| `sessionstorage-set <key> <value>` | Set a sessionStorage key/value pair |
| `sessionstorage-delete <key>` | Delete a sessionStorage key |
| `sessionstorage-clear` | Clear all sessionStorage |

All storage commands return structured JSON data (no page snapshot), consistent with cookie commands.

## Changes

- **src/client/commands.ts** — 10 new `declareCommand()` entries with zod schemas, added to `allCommands` and registry
- **src/cypress/driverSpec.ts** — 10 new `executeCommand()` cases using `cy.window()` + `win.localStorage`/`win.sessionStorage`, added to `STRUCTURED_DATA_ONLY_COMMANDS`
- **src/daemon/commandBuilder.ts** — Storage cases grouped with existing cookie patterns
- **docs/COMMANDS.md** — Updated Storage table with all 10 commands
- **tests/unit/client/commands.test.ts** — Schema validation + parseCommand tests for all 10 commands, updated counts (51→61, 55→65)
- **tests/unit/daemon/buildQueuedCommand.test.ts** — Storage command mapping tests

## Checks

- [x] `npx tsc --noEmit` — passes
- [x] `npx vitest run` — 983 passed (1 pre-existing flaky queueBridge test)
- [x] `npx eslint src/ tests/` — clean
- [x] `npm run build` — clean