### PR TITLE
feat: next steps tasks 1-3 (flaky test fix, run command, CI/CD)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,22 @@
+name: CI
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [20]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: npm
+      - run: npm ci
+      - run: npx tsc --noEmit
+      - run: npx eslint src/ tests/
+      - run: npx vitest run --project happy-dom --project node

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,17 @@
+name: E2E
+on:
+  push:
+    branches: [main]
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - run: npm run build
+      - run: npx vitest run --project e2e

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -93,10 +93,12 @@ or require a running Cypress session.
 
 ### Execution
 
-| Command    | Syntax                                | Description                                                       |
-| ---------- | ------------------------------------- | ----------------------------------------------------------------- |
-| `run-code` | `cypress-cli run-code <code>`         | Execute JS in browser (`cy.window().then(win => win.eval(code))`) |
-| `eval`     | `cypress-cli eval <expression> [ref]` | Evaluate JS expression on page or on a specific element           |
+| Command    | Syntax                                                     | Description                                                       |
+| ---------- | ---------------------------------------------------------- | ----------------------------------------------------------------- |
+| `run-code` | `cypress-cli run-code <code>`                              | Execute JS in browser (`cy.window().then(win => win.eval(code))`) |
+| `eval`     | `cypress-cli eval <expression> [ref]`                      | Evaluate JS expression on page or on a specific element           |
+| `cyrun`    | `cypress-cli cyrun <code>`                                 | Execute arbitrary Cypress chain string in the runner context       |
+| `run`      | `cypress-cli run <file> [--browser chrome\|electron] [--headed]` | Run a Cypress test file and report structured results             |
 
 ### Wait
 

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
 		"test:e2e": "vitest run tests/e2e/",
 		"typecheck": "tsc --noEmit",
 		"lint": "eslint src/ tests/",
-		"clean": "rm -rf dist/"
+		"clean": "rm -rf dist/",
+		"prepublishOnly": "npm run lint && npm run typecheck && npm test && npm run build"
 	},
 	"engines": {
 		"node": ">=18.0.0"
@@ -44,6 +45,7 @@
 	},
 	"files": [
 		"dist/",
+		"bin/",
 		"skills/",
 		"README.md",
 		"LICENSE"

--- a/src/client/cli.ts
+++ b/src/client/cli.ts
@@ -214,6 +214,27 @@ export function formatResult(result: ClientResult, asJson: boolean): string {
 		return `Installed skills to: ${resultObj['installedPath']}`;
 	}
 
+	// Run command result (structured test results)
+	if (typeof resultObj?.['totalTests'] === 'number') {
+		const lines: string[] = [];
+		const passed = resultObj['success'] ? 'PASSED' : 'FAILED';
+		lines.push(`### Test Run: ${passed}`);
+		lines.push(`- Total: ${resultObj['totalTests']}`);
+		lines.push(`- Passed: ${resultObj['totalPassed']}`);
+		lines.push(`- Failed: ${resultObj['totalFailed']}`);
+		lines.push(`- Duration: ${resultObj['duration']}ms`);
+		const failures = resultObj['failures'] as
+			| Array<{ test: string; error: string }>
+			| undefined;
+		if (failures && failures.length > 0) {
+			lines.push('', '### Failures');
+			for (const f of failures) {
+				lines.push(`- ${f.test}: ${f.error}`);
+			}
+		}
+		return lines.join('\n');
+	}
+
 	// Build output lines — page metadata + snapshot file path (never inline YAML)
 	const lines: string[] = [];
 

--- a/src/client/commands.ts
+++ b/src/client/commands.ts
@@ -841,6 +841,29 @@ export const upload = declareCommand({
 });
 
 // ---------------------------------------------------------------------------
+// Run command (standalone test execution)
+// ---------------------------------------------------------------------------
+
+export const runTest = declareCommand({
+	name: 'run',
+	category: 'execution',
+	description: 'Run a Cypress test file and report results',
+	args: z.object({
+		file: z.string().describe('Path to the test file to run'),
+	}),
+	options: z.object({
+		browser: z
+			.enum(['chrome', 'electron'])
+			.optional()
+			.describe('Browser to use (default: electron)'),
+		headed: z
+			.boolean()
+			.optional()
+			.describe('Run in headed mode (default: false)'),
+	}),
+});
+
+// ---------------------------------------------------------------------------
 // Command registry
 // ---------------------------------------------------------------------------
 
@@ -911,6 +934,7 @@ export const allCommands = [
 	dialogAccept,
 	dialogDismiss,
 	resize,
+	runTest,
 ] as const;
 
 /**
@@ -1136,6 +1160,12 @@ export function buildRegistry(): ReadonlyMap<string, CommandRegistryEntry> {
 	registry.set('upload', {
 		schema: upload,
 		positionals: ['ref', 'file'],
+	});
+
+	// Run (standalone test execution)
+	registry.set('run', {
+		schema: runTest,
+		positionals: ['file'],
 	});
 
 	// Aliases (playwright-cli naming compatibility)

--- a/src/daemon/daemon.ts
+++ b/src/daemon/daemon.ts
@@ -30,6 +30,7 @@ import {
 	handleUndo,
 	handleExport,
 	handleInterceptList,
+	handleRunTest,
 	trackInterceptState,
 	checkInterceptDrift,
 } from './handlers.js';
@@ -401,6 +402,11 @@ export class Daemon {
 
 		if (action === 'intercept-list') {
 			handleInterceptList(conn, message, this._findRunningSession());
+			return;
+		}
+
+		if (action === 'run') {
+			void handleRunTest(conn, message);
 			return;
 		}
 

--- a/src/daemon/handlers.ts
+++ b/src/daemon/handlers.ts
@@ -249,6 +249,132 @@ export function checkInterceptDrift(
 	}
 }
 
+/**
+ * Handle the `run` daemon-local command.
+ * Runs a Cypress test file in a separate cypress.run() invocation
+ * and returns structured results.
+ */
+export async function handleRunTest(
+	conn: SocketConnection,
+	message: CommandMessage,
+): Promise<void> {
+	const args = message.params.args;
+	const file = args._[1] as string | undefined;
+	const options = stripPositionals(args);
+
+	if (!file) {
+		sendError(conn, {
+			id: message.id,
+			error: 'run requires a file argument.',
+		});
+		return;
+	}
+
+	const resolvedFile = path.resolve(file);
+
+	// Validate file extension
+	if (!/\.cy\.[tj]s$/.test(resolvedFile)) {
+		sendError(conn, {
+			id: message.id,
+			error: `Invalid test file extension. Expected .cy.ts or .cy.js, got: ${path.basename(resolvedFile)}`,
+		});
+		return;
+	}
+
+	// Validate file exists
+	try {
+		await fs.access(resolvedFile);
+	} catch {
+		sendError(conn, {
+			id: message.id,
+			error: `Test file not found: ${resolvedFile}`,
+		});
+		return;
+	}
+
+	try {
+		const cypress = await import('cypress');
+		const result = await cypress.default.run({
+			spec: resolvedFile,
+			browser: (options['browser'] as string) ?? 'electron',
+			headed: options['headed'] === true,
+		} as Record<string, unknown>);
+
+		// Cypress returns CypressFailedRunResult on infrastructure failure
+		if (
+			result &&
+			typeof result === 'object' &&
+			'status' in result &&
+			(result as { status: string }).status === 'failed'
+		) {
+			const failedResult = result as { message?: string; failures?: number };
+			const response: ResponseMessage = {
+				id: message.id,
+				result: {
+					success: false,
+					totalTests: 0,
+					totalPassed: 0,
+					totalFailed: failedResult.failures ?? 0,
+					failures: [],
+					duration: 0,
+					error: failedResult.message ?? 'Cypress run failed',
+				},
+			};
+			conn.send(response);
+			return;
+		}
+
+		// Normal CypressRunResult
+		const runResult = result as {
+			totalTests?: number;
+			totalPassed?: number;
+			totalFailed?: number;
+			totalDuration?: number;
+			runs?: Array<{
+				tests?: Array<{
+					title?: string[];
+					state?: string;
+					displayError?: string | null;
+				}>;
+			}>;
+		};
+
+		const failures: Array<{ test: string; error: string }> = [];
+		if (runResult.runs) {
+			for (const run of runResult.runs) {
+				if (run.tests) {
+					for (const test of run.tests) {
+						if (test.state === 'failed' && test.displayError) {
+							failures.push({
+								test: (test.title ?? []).join(' > '),
+								error: test.displayError,
+							});
+						}
+					}
+				}
+			}
+		}
+
+		const response: ResponseMessage = {
+			id: message.id,
+			result: {
+				success: (runResult.totalFailed ?? 0) === 0,
+				totalTests: runResult.totalTests ?? 0,
+				totalPassed: runResult.totalPassed ?? 0,
+				totalFailed: runResult.totalFailed ?? 0,
+				failures,
+				duration: runResult.totalDuration ?? 0,
+			},
+		};
+		conn.send(response);
+	} catch (err) {
+		sendError(conn, {
+			id: message.id,
+			error: err instanceof Error ? err.message : String(err),
+		});
+	}
+}
+
 function sendError(conn: SocketConnection, message: ErrorMessage): void {
 	conn.send(message);
 }

--- a/src/daemon/protocol.ts
+++ b/src/daemon/protocol.ts
@@ -48,6 +48,13 @@ const responseMessageSchema = z.object({
 		testFile: z.string().optional(),
 		filePath: z.string().optional(),
 		snapshotFilePath: z.string().optional(),
+		totalTests: z.number().optional(),
+		totalPassed: z.number().optional(),
+		totalFailed: z.number().optional(),
+		failures: z
+			.array(z.object({ test: z.string(), error: z.string() }))
+			.optional(),
+		duration: z.number().optional(),
 	}),
 });
 

--- a/tests/unit/client/commands.test.ts
+++ b/tests/unit/client/commands.test.ts
@@ -72,6 +72,7 @@ import {
 	sessionstorageDelete,
 	sessionstorageClear,
 	console_,
+	runTest,
 } from '../../../src/client/commands.js';
 import { z } from 'zod';
 
@@ -109,12 +110,12 @@ describe('declareCommand', () => {
 });
 
 describe('command schemas', () => {
-	it('defines all 63 commands', () => {
-		expect(allCommands).toHaveLength(63);
+	it('defines all 64 commands', () => {
+		expect(allCommands).toHaveLength(64);
 	});
 
 	it('registers all commands plus aliases in the registry', () => {
-		expect(commandRegistry.size).toBe(67);
+		expect(commandRegistry.size).toBe(68);
 	});
 
 	describe('categories', () => {
@@ -187,6 +188,7 @@ describe('command schemas', () => {
 			expect(runCode.category).toBe('execution');
 			expect(eval_.category).toBe('execution');
 			expect(cyrun.category).toBe('execution');
+			expect(runTest.category).toBe('execution');
 		});
 
 		it('has network commands', () => {
@@ -795,6 +797,30 @@ describe('command schemas', () => {
 			expect(
 				console_.options.safeParse({ clear: true }),
 			).toMatchObject({ success: true });
+		});
+
+		it('run requires file', () => {
+			const good = runTest.args.safeParse({ file: 'test.cy.ts' });
+			expect(good.success).toBe(true);
+
+			const missing = runTest.args.safeParse({});
+			expect(missing.success).toBe(false);
+		});
+
+		it('run options are optional', () => {
+			const noOptions = runTest.options.safeParse({});
+			expect(noOptions.success).toBe(true);
+
+			const withBrowser = runTest.options.safeParse({ browser: 'chrome' });
+			expect(withBrowser.success).toBe(true);
+
+			const withHeaded = runTest.options.safeParse({ headed: true });
+			expect(withHeaded.success).toBe(true);
+
+			const invalidBrowser = runTest.options.safeParse({
+				browser: 'firefox',
+			});
+			expect(invalidBrowser.success).toBe(false);
 		});
 	});
 });

--- a/tests/unit/cypress/queueBridge.test.ts
+++ b/tests/unit/cypress/queueBridge.test.ts
@@ -48,9 +48,8 @@ let socketPath: string;
 let bridge: QueueBridge;
 
 beforeEach(async () => {
-socketDir = await fs.mkdtemp(path.join(os.tmpdir(), 'cypress-cli-bridge-'));
-socketPath = path.join(socketDir, `bridge-${Date.now()}-${Math.random()}.sock`);
-
+		socketDir = await fs.mkdtemp(path.join(os.tmpdir(), 'cb-'));
+		socketPath = path.join(socketDir, 'bridge.sock');
 taskMocks.getCommand.mockReset();
 taskMocks.commandResult.mockReset();
 taskMocks.createTaskHandlers.mockReset().mockReturnValue({

--- a/tests/unit/daemon/handlers.test.ts
+++ b/tests/unit/daemon/handlers.test.ts
@@ -1,9 +1,13 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
 
 import type { SocketConnection } from '../../../src/daemon/connection.js';
 import {
 	handleHistory,
 	handleStatus,
+	handleRunTest,
 	trackInterceptState,
 	checkInterceptDrift,
 } from '../../../src/daemon/handlers.js';
@@ -12,6 +16,14 @@ import type {
 	ResponseMessage,
 } from '../../../src/daemon/protocol.js';
 import { Session } from '../../../src/daemon/session.js';
+
+const cypressMock = vi.hoisted(() => ({
+	run: vi.fn(),
+}));
+
+vi.mock('cypress', () => ({
+	default: cypressMock,
+}));
 
 function makeConnection(): {
 	conn: SocketConnection;
@@ -125,5 +137,127 @@ describe('daemon handlers', () => {
 		);
 
 		expect(session.intercepts).toEqual([]);
+	});
+});
+
+describe('handleRunTest', () => {
+	it('returns error when file argument is missing', async () => {
+		const { conn, send } = makeConnection();
+
+		await handleRunTest(conn, makeMessage('run'));
+
+		expect(send).toHaveBeenCalledWith(
+			expect.objectContaining({
+				id: 1,
+				error: 'run requires a file argument.',
+			}),
+		);
+	});
+
+	it('rejects files without .cy.ts or .cy.js extension', async () => {
+		const { conn, send } = makeConnection();
+
+		await handleRunTest(conn, makeMessage('run', ['test.ts']));
+
+		expect(send).toHaveBeenCalledWith(
+			expect.objectContaining({
+				id: 1,
+				error: expect.stringContaining('Invalid test file extension'),
+			}),
+		);
+	});
+
+	it('returns error when file does not exist', async () => {
+		const { conn, send } = makeConnection();
+
+		await handleRunTest(conn, makeMessage('run', ['nonexistent.cy.ts']));
+
+		expect(send).toHaveBeenCalledWith(
+			expect.objectContaining({
+				id: 1,
+				error: expect.stringContaining('Test file not found'),
+			}),
+		);
+	});
+
+	it('maps successful Cypress run result to structured response', async () => {
+		const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'run-test-'));
+		const testFile = path.join(tmpDir, 'test.cy.ts');
+		await fs.writeFile(testFile, 'describe("test", () => { it("passes", () => {}) })');
+
+		const { conn, send } = makeConnection();
+
+		cypressMock.run.mockResolvedValue({
+			totalTests: 3,
+			totalPassed: 2,
+			totalFailed: 1,
+			totalDuration: 1500,
+			runs: [
+				{
+					tests: [
+						{ title: ['Suite', 'passes'], state: 'passed', displayError: null },
+						{ title: ['Suite', 'also passes'], state: 'passed', displayError: null },
+						{ title: ['Suite', 'fails'], state: 'failed', displayError: 'AssertionError: expected true to be false' },
+					],
+				},
+			],
+		});
+
+		await handleRunTest(conn, makeMessage('run', [testFile]));
+
+		expect(send).toHaveBeenCalledWith(
+			expect.objectContaining({
+				id: 1,
+				result: expect.objectContaining({
+					success: false,
+					totalTests: 3,
+					totalPassed: 2,
+					totalFailed: 1,
+					duration: 1500,
+					failures: [
+						{
+							test: 'Suite > fails',
+							error: 'AssertionError: expected true to be false',
+						},
+					],
+				}),
+			}),
+		);
+
+		await fs.rm(tmpDir, { recursive: true, force: true });
+	});
+
+	it('maps Cypress failed run result (infrastructure failure)', async () => {
+		const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'run-test-'));
+		const testFile = path.join(tmpDir, 'test.cy.ts');
+		await fs.writeFile(testFile, '// empty');
+
+		const { conn, send } = makeConnection();
+
+		cypressMock.run.mockResolvedValue({
+			status: 'failed',
+			message: 'Could not find Cypress binary',
+			failures: 1,
+		});
+
+		await handleRunTest(conn, makeMessage('run', [testFile]));
+
+		expect(send).toHaveBeenCalledWith(
+			expect.objectContaining({
+				id: 1,
+				result: expect.objectContaining({
+					success: false,
+					totalTests: 0,
+					totalFailed: 1,
+					error: 'Could not find Cypress binary',
+				}),
+			}),
+		);
+
+		await fs.rm(tmpDir, { recursive: true, force: true });
+	});
+
+	afterEach(() => {
+		cypressMock.run.mockReset();
 	});
 });


### PR DESCRIPTION
## Summary

Implements all three tasks from the Next Steps Plan.

### Task 1: Fix flaky queueBridge test
The socket path in `tests/unit/cypress/queueBridge.test.ts` exceeded macOS's 104-char `sun_path` limit for Unix domain sockets. `server.listen()` silently succeeds but the socket file isn't created, causing `fs.access()` to fail with ENOENT. Fixed by shortening the temp directory prefix and socket filename. Verified stable across 10 consecutive runs.

### Task 2: Implement `run` command (closes #81)
Added a daemon-local `run` command that executes a standalone Cypress test file via `cypress.default.run()`:
- Validates file extension (`.cy.ts`/`.cy.js`) and existence
- Returns structured results: success/fail, test counts, duration, failure details
- Does NOT affect the active REPL session
- Updated protocol types, CLI formatting, command registry (64 commands / 68 registry entries)
- Added unit tests for schema validation and handler logic

### Task 3: CI/CD pipeline (closes #15)
- `.github/workflows/ci.yml`: typecheck + lint + unit/integration tests on push/PR to main
- `.github/workflows/e2e.yml`: e2e tests on push to main (20min timeout)
- `.github/dependabot.yml`: weekly npm + GitHub Actions dependency updates
- Added `bin/` to `files` field and `prepublishOnly` script to `package.json`
- Tarball is 175KB (well under 500KB limit)

## Verification
- `npx tsc --noEmit` ✅
- `npx vitest run` — 1009 tests passing ✅
- `npx eslint src/ tests/` ✅
- `npm run build` ✅
- `npm pack --dry-run` — 175KB ✅