### PR TITLE
fix: display history entries and undo action in CLI output

### DIFF
--- a/src/client/cli.ts
+++ b/src/client/cli.ts
@@ -235,6 +235,36 @@ export function formatResult(result: ClientResult, asJson: boolean): string {
 		return lines.join('\n');
 	}
 
+	if (typeof resultObj?.['undoneAction'] === 'string') {
+		return resultObj['undoneAction'];
+	}
+
+	if (typeof resultObj?.['historyEntries'] === 'string') {
+		try {
+			const entries = JSON.parse(resultObj['historyEntries']) as Array<{
+				index: number;
+				action: string;
+				ref?: string;
+				text?: string;
+				success: boolean;
+				active: boolean;
+			}>;
+			if (entries.length === 0) {
+				return 'No commands in history.';
+			}
+			const lines = entries.map((e) => {
+				const status = e.active ? (e.success ? '✓' : '✗') : '↩';
+				const parts = [e.action];
+				if (e.ref) parts.push(e.ref);
+				if (e.text) parts.push(e.text);
+				return `  ${status} ${e.index}: ${parts.join(' ')}`;
+			});
+			return `### History (${entries.length} commands)\n${lines.join('\n')}`;
+		} catch {
+			return resultObj['historyEntries'];
+		}
+	}
+
 	// Build output lines — page metadata + snapshot file path (never inline YAML)
 	const lines: string[] = [];
 

--- a/src/daemon/handlers.ts
+++ b/src/daemon/handlers.ts
@@ -74,7 +74,7 @@ export function handleHistory(
 		id: message.id,
 		result: {
 			success: true,
-			snapshot: JSON.stringify(formatted),
+			historyEntries: JSON.stringify(formatted),
 		},
 	};
 	conn.send(response);
@@ -109,7 +109,7 @@ export function handleUndo(
 		id: message.id,
 		result: {
 			success: true,
-			snapshot: `Undone: ${undone.command.action}${undone.command.ref ? ' ' + undone.command.ref : ''}`,
+			undoneAction: `Undone: ${undone.command.action}${undone.command.ref ? ' ' + undone.command.ref : ''}`,
 		},
 	};
 	conn.send(response);
@@ -228,7 +228,11 @@ export function checkInterceptDrift(
 	command: QueuedCommand,
 	result: CommandResult,
 ): void {
-	const DRIFT_TRACKED_ACTIONS = new Set(['network', 'intercept', 'unintercept']);
+	const DRIFT_TRACKED_ACTIONS = new Set([
+		'network',
+		'intercept',
+		'unintercept',
+	]);
 	if (!DRIFT_TRACKED_ACTIONS.has(command.action)) return;
 
 	if (!result.evalResult) return;

--- a/src/daemon/protocol.ts
+++ b/src/daemon/protocol.ts
@@ -55,6 +55,8 @@ const responseMessageSchema = z.object({
 			.array(z.object({ test: z.string(), error: z.string() }))
 			.optional(),
 		duration: z.number().optional(),
+		historyEntries: z.string().optional(),
+		undoneAction: z.string().optional(),
 	}),
 });
 

--- a/tests/e2e/export.test.ts
+++ b/tests/e2e/export.test.ts
@@ -7,11 +7,7 @@
 
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 
-import {
-	setupE2E,
-	isSuccess,
-	type E2EContext,
-} from './helpers.js';
+import { setupE2E, isSuccess, type E2EContext } from './helpers.js';
 import type { ResponseMessage } from '../../src/daemon/protocol.js';
 
 describe('E2E: export', () => {
@@ -27,10 +23,11 @@ describe('E2E: export', () => {
 
 	it('executes commands and exports a valid test file', async () => {
 		// Execute a navigate command (generates a cypressCommand for codegen)
-		const navResponse = await ctx.sendCommand(
-			60,
-			['navigate', '_', `http://127.0.0.1:${ctx.port}/simple.html`],
-		);
+		const navResponse = await ctx.sendCommand(60, [
+			'navigate',
+			'_',
+			`http://127.0.0.1:${ctx.port}/simple.html`,
+		]);
 		expect(isSuccess(navResponse)).toBe(true);
 
 		// Take a snapshot (no-op command but needed for flow)
@@ -55,11 +52,10 @@ describe('E2E: export', () => {
 	}, 60_000);
 
 	it('export with custom describe and it names', async () => {
-		const exportResponse = await ctx.sendCommand(
-			63,
-			['export'],
-			{ describe: 'My Test Suite', it: 'should work' },
-		);
+		const exportResponse = await ctx.sendCommand(63, ['export'], {
+			describe: 'My Test Suite',
+			it: 'should work',
+		});
 		expect(isSuccess(exportResponse)).toBe(true);
 
 		const result = (exportResponse as ResponseMessage).result;
@@ -74,7 +70,8 @@ describe('E2E: export', () => {
 		const snapshotResponse = await ctx.sendCommand(65, ['snapshot']);
 		expect(isSuccess(snapshotResponse)).toBe(true);
 
-		const snapshot = (snapshotResponse as ResponseMessage).result.snapshot ?? '';
+		const snapshot =
+			(snapshotResponse as ResponseMessage).result.snapshot ?? '';
 		const helloRef = snapshot.match(/button "Say Hello" \[ref=(e\d+)\]/)?.[1];
 		expect(helloRef).toBeDefined();
 
@@ -94,10 +91,10 @@ describe('E2E: export', () => {
 		expect(isSuccess(historyResponse)).toBe(true);
 
 		const result = (historyResponse as ResponseMessage).result;
-		// History is returned as a JSON string in the snapshot field
-		expect(result.snapshot).toBeDefined();
+		// History is returned as a JSON string in the historyEntries field
+		expect(result.historyEntries).toBeDefined();
 
-		const history = JSON.parse(result.snapshot!);
+		const history = JSON.parse(result.historyEntries!);
 		expect(Array.isArray(history)).toBe(true);
 		expect(history.length).toBeGreaterThan(0);
 

--- a/tests/unit/client/cli.test.ts
+++ b/tests/unit/client/cli.test.ts
@@ -325,6 +325,50 @@ describe('formatResult', () => {
 			'Installed skills to: .github/skills/cypress-cli',
 		);
 	});
+
+	it('formats undoneAction when present', () => {
+		const result: ClientResult = {
+			success: true,
+			result: {
+				undoneAction: 'Undone: type e40',
+			},
+		};
+		expect(formatResult(result, false)).toBe('Undone: type e40');
+	});
+
+	it('formats history entries when present', () => {
+		const entries = [
+			{ index: 0, action: 'click', ref: 'e1', success: true, active: true },
+			{
+				index: 1,
+				action: 'type',
+				ref: 'e2',
+				text: 'hello',
+				success: true,
+				active: false,
+			},
+		];
+		const result: ClientResult = {
+			success: true,
+			result: {
+				historyEntries: JSON.stringify(entries),
+			},
+		};
+		const output = formatResult(result, false);
+		expect(output).toContain('### History (2 commands)');
+		expect(output).toContain('✓ 0: click e1');
+		expect(output).toContain('↩ 1: type e2 hello');
+	});
+
+	it('shows empty history message', () => {
+		const result: ClientResult = {
+			success: true,
+			result: {
+				historyEntries: JSON.stringify([]),
+			},
+		};
+		expect(formatResult(result, false)).toBe('No commands in history.');
+	});
 });
 
 // ---------------------------------------------------------------------------

--- a/tests/unit/daemon/handlers.test.ts
+++ b/tests/unit/daemon/handlers.test.ts
@@ -70,7 +70,10 @@ describe('daemon handlers', () => {
 
 	it('formats history entries with active flags based on undo state', () => {
 		const { conn, send } = makeConnection();
-		const session = new Session({ id: 'session-1', url: 'https://example.com' });
+		const session = new Session({
+			id: 'session-1',
+			url: 'https://example.com',
+		});
 
 		session.recordHistory(
 			{ id: 1, action: 'click', ref: 'e1' },
@@ -87,7 +90,7 @@ describe('daemon handlers', () => {
 		const response = send.mock.calls[0]?.[0];
 		expect(response?.id).toBe(1);
 		expect(response?.result.success).toBe(true);
-		expect(JSON.parse(String(response?.result.snapshot))).toEqual([
+		expect(JSON.parse(String(response?.result.historyEntries))).toEqual([
 			expect.objectContaining({
 				index: 0,
 				action: 'click',


### PR DESCRIPTION
Fixes #126

## Problem

`history` and `undo` commands returned `"OK"` instead of their actual data in human-readable mode. Both handlers stored response data in the `snapshot` field, which `formatResult()` strips before rendering.

## Changes

- **`src/daemon/protocol.ts`**: Added `historyEntries` and `undoneAction` fields to response schema
- **`src/daemon/handlers.ts`**: `handleHistory()` uses `historyEntries`; `handleUndo()` uses `undoneAction`
- **`src/client/cli.ts`**: `formatResult()` formats history as a table with ✓/✗/↩ status markers
- **Tests**: Updated existing tests, added new formatting tests

## Before / After

```
# Before
$ cypress-cli history
OK

$ cypress-cli undo
OK

# After
$ cypress-cli history
### History (4 commands)
  ✓ 0: navigate https://example.cypress.io/commands/actions
  ✓ 1: snapshot
  ✓ 2: type e40 test@test.com
  ↩ 3: click e108

$ cypress-cli undo
Undone: click e108
```

## Validation

- All 1012 tests pass
- `npx tsc --noEmit` clean
- `npx eslint src/ tests/` clean
- Live validated against https://example.cypress.io/commands/actions

Found during issue #66 LLM validation exercise.