### PR TITLE
feat: 1.0 blocker fixes, REPL exposure, and release docs

### DIFF
--- a/.claude/skills/playwright-cli/SKILL.md
+++ b/.claude/skills/playwright-cli/SKILL.md
@@ -1,0 +1,344 @@
+Í›---
+name: playwright-cli
+description: Automate browser interactions, test web pages and work with Playwright tests.
+allowed-tools: Bash(playwright-cli:*) Bash(npx:*) Bash(npm:*)
+---
+
+# Browser Automation with playwright-cli
+
+## Quick start
+
+```bash
+# open new browser
+playwright-cli open
+# navigate to a page
+playwright-cli goto https://playwright.dev
+# interact with the page using refs from the snapshot
+playwright-cli click e15
+playwright-cli type "page.click"
+playwright-cli press Enter
+# take a screenshot (rarely used, as snapshot is more common)
+playwright-cli screenshot
+# close the browser
+playwright-cli close
+```
+
+## Commands
+
+### Core
+
+```bash
+playwright-cli open
+# open and navigate right away
+playwright-cli open https://example.com/
+playwright-cli goto https://playwright.dev
+playwright-cli type "search query"
+playwright-cli click e3
+playwright-cli dblclick e7
+# --submit presses Enter after filling the element
+playwright-cli fill e5 "user@example.com"  --submit
+playwright-cli drag e2 e8
+playwright-cli hover e4
+playwright-cli select e9 "option-value"
+playwright-cli upload ./document.pdf
+playwright-cli check e12
+playwright-cli uncheck e12
+playwright-cli snapshot
+playwright-cli eval "document.title"
+playwright-cli eval "el => el.textContent" e5
+# get element id, class, or any attribute not visible in the snapshot
+playwright-cli eval "el => el.id" e5
+playwright-cli eval "el => el.getAttribute('data-testid')" e5
+playwright-cli dialog-accept
+playwright-cli dialog-accept "confirmation text"
+playwright-cli dialog-dismiss
+playwright-cli resize 1920 1080
+playwright-cli close
+```
+
+### Navigation
+
+```bash
+playwright-cli go-back
+playwright-cli go-forward
+playwright-cli reload
+```
+
+### Keyboard
+
+```bash
+playwright-cli press Enter
+playwright-cli press ArrowDown
+playwright-cli keydown Shift
+playwright-cli keyup Shift
+```
+
+### Mouse
+
+```bash
+playwright-cli mousemove 150 300
+playwright-cli mousedown
+playwright-cli mousedown right
+playwright-cli mouseup
+playwright-cli mouseup right
+playwright-cli mousewheel 0 100
+```
+
+### Save as
+
+```bash
+playwright-cli screenshot
+playwright-cli screenshot e5
+playwright-cli screenshot --filename=page.png
+playwright-cli pdf --filename=page.pdf
+```
+
+### Tabs
+
+```bash
+playwright-cli tab-list
+playwright-cli tab-new
+playwright-cli tab-new https://example.com/page
+playwright-cli tab-close
+playwright-cli tab-close 2
+playwright-cli tab-select 0
+```
+
+### Storage
+
+```bash
+playwright-cli state-save
+playwright-cli state-save auth.json
+playwright-cli state-load auth.json
+
+# Cookies
+playwright-cli cookie-list
+playwright-cli cookie-list --domain=example.com
+playwright-cli cookie-get session_id
+playwright-cli cookie-set session_id abc123
+playwright-cli cookie-set session_id abc123 --domain=example.com --httpOnly --secure
+playwright-cli cookie-delete session_id
+playwright-cli cookie-clear
+
+# LocalStorage
+playwright-cli localstorage-list
+playwright-cli localstorage-get theme
+playwright-cli localstorage-set theme dark
+playwright-cli localstorage-delete theme
+playwright-cli localstorage-clear
+
+# SessionStorage
+playwright-cli sessionstorage-list
+playwright-cli sessionstorage-get step
+playwright-cli sessionstorage-set step 3
+playwright-cli sessionstorage-delete step
+playwright-cli sessionstorage-clear
+```
+
+### Network
+
+```bash
+playwright-cli route "**/*.jpg" --status=404
+playwright-cli route "https://api.example.com/**" --body='{"mock": true}'
+playwright-cli route-list
+playwright-cli unroute "**/*.jpg"
+playwright-cli unroute
+```
+
+### DevTools
+
+```bash
+playwright-cli console
+playwright-cli console warning
+playwright-cli network
+playwright-cli run-code "async page => await page.context().grantPermissions(['geolocation'])"
+playwright-cli run-code --filename=script.js
+playwright-cli tracing-start
+playwright-cli tracing-stop
+playwright-cli video-start video.webm
+playwright-cli video-chapter "Chapter Title" --description="Details" --duration=2000
+playwright-cli video-stop
+```
+
+## Raw output
+
+The global `--raw` option strips page status, generated code, and snapshot sections from the output, returning only the result value. Use it to pipe command output into other tools. Commands that don't produce output return nothing.
+
+```bash
+playwright-cli --raw eval "JSON.stringify(performance.timing)" | jq '.loadEventEnd - .navigationStart'
+playwright-cli --raw eval "JSON.stringify([...document.querySelectorAll('a')].map(a => a.href))" > links.json
+playwright-cli --raw snapshot > before.yml
+playwright-cli click e5
+playwright-cli --raw snapshot > after.yml
+diff before.yml after.yml
+TOKEN=$(playwright-cli --raw cookie-get session_id)
+playwright-cli --raw localstorage-get theme
+```
+
+## Open parameters
+```bash
+# Use specific browser when creating session
+playwright-cli open --browser=chrome
+playwright-cli open --browser=firefox
+playwright-cli open --browser=webkit
+playwright-cli open --browser=msedge
+
+# Use persistent profile (by default profile is in-memory)
+playwright-cli open --persistent
+# Use persistent profile with custom directory
+playwright-cli open --profile=/path/to/profile
+
+# Connect to browser via extension
+playwright-cli attach --extension
+
+# Start with config file
+playwright-cli open --config=my-config.json
+
+# Close the browser
+playwright-cli close
+# Delete user data for the default session
+playwright-cli delete-data
+```
+
+## Snapshots
+
+After each command, playwright-cli provides a snapshot of the current browser state.
+
+```bash
+> playwright-cli goto https://example.com
+### Page
+- Page URL: https://example.com/
+- Page Title: Example Domain
+### Snapshot
+[Snapshot](.playwright-cli/page-2026-02-14T19-22-42-679Z.yml)
+```
+
+You can also take a snapshot on demand using `playwright-cli snapshot` command. All the options below can be combined as needed.
+
+```bash
+# default - save to a file with timestamp-based name
+playwright-cli snapshot
+
+# save to file, use when snapshot is a part of the workflow result
+playwright-cli snapshot --filename=after-click.yaml
+
+# snapshot an element instead of the whole page
+playwright-cli snapshot "#main"
+
+# limit snapshot depth for efficiency, take a partial snapshot afterwards
+playwright-cli snapshot --depth=4
+playwright-cli snapshot e34
+```
+
+## Targeting elements
+
+By default, use refs from the snapshot to interact with page elements.
+
+```bash
+# get snapshot with refs
+playwright-cli snapshot
+
+# interact using a ref
+playwright-cli click e15
+```
+
+You can also use css selectors or Playwright locators.
+
+```bash
+# css selector
+playwright-cli click "#main > button.submit"
+
+# role locator
+playwright-cli click "getByRole('button', { name: 'Submit' })"
+
+# test id
+playwright-cli click "getByTestId('submit-button')"
+```
+
+## Browser Sessions
+
+```bash
+# create new browser session named "mysession" with persistent profile
+playwright-cli -s=mysession open example.com --persistent
+# same with manually specified profile directory (use when requested explicitly)
+playwright-cli -s=mysession open example.com --profile=/path/to/profile
+playwright-cli -s=mysession click e6
+playwright-cli -s=mysession close  # stop a named browser
+playwright-cli -s=mysession delete-data  # delete user data for persistent session
+
+playwright-cli list
+# Close all browsers
+playwright-cli close-all
+# Forcefully kill all browser processes
+playwright-cli kill-all
+```
+
+## Installation
+
+If global `playwright-cli` command is not available, try a local version via `npx playwright-cli`:
+
+```bash
+npx --no-install playwright-cli --version
+```
+
+When local version is available, use `npx playwright-cli` in all commands. Otherwise, install `playwright-cli` as a global command:
+
+```bash
+npm install -g @playwright/cli@latest
+```
+
+## Example: Form submission
+
+```bash
+playwright-cli open https://example.com/form
+playwright-cli snapshot
+
+playwright-cli fill e1 "user@example.com"
+playwright-cli fill e2 "password123"
+playwright-cli click e3
+playwright-cli snapshot
+playwright-cli close
+```
+
+## Example: Multi-tab workflow
+
+```bash
+playwright-cli open https://example.com
+playwright-cli tab-new https://example.com/other
+playwright-cli tab-list
+playwright-cli tab-select 0
+playwright-cli snapshot
+playwright-cli close
+```
+
+## Example: Debugging with DevTools
+
+```bash
+playwright-cli open https://example.com
+playwright-cli click e4
+playwright-cli fill e7 "test"
+playwright-cli console
+playwright-cli network
+playwright-cli close
+```
+
+```bash
+playwright-cli open https://example.com
+playwright-cli tracing-start
+playwright-cli click e4
+playwright-cli fill e7 "test"
+playwright-cli tracing-stop
+playwright-cli close
+```
+
+## Specific tasks
+
+* **Running and Debugging Playwright tests** [references/playwright-tests.md](references/playwright-tests.md)
+* **Request mocking** [references/request-mocking.md](references/request-mocking.md)
+* **Running Playwright code** [references/running-code.md](references/running-code.md)
+* **Browser session management** [references/session-management.md](references/session-management.md)
+* **Storage state (cookies, localStorage)** [references/storage-state.md](references/storage-state.md)
+* **Test generation** [references/test-generation.md](references/test-generation.md)
+* **Tracing** [references/tracing.md](references/tracing.md)
+* **Video recording** [references/video-recording.md](references/video-recording.md)
+* **Inspecting element attributes** [references/element-attributes.md](references/element-attributes.md)

--- a/.claude/skills/playwright-cli/references/element-attributes.md
+++ b/.claude/skills/playwright-cli/references/element-attributes.md
@@ -1,0 +1,23 @@
+# Inspecting Element Attributes
+
+When the snapshot doesn't show an element's `id`, `class`, `data-*` attributes, or other DOM properties, use `eval` to inspect them.
+
+## Examples
+
+```bash
+playwright-cli snapshot
+# snapshot shows a button as e7 but doesn't reveal its id or data attributes
+
+# get the element's id
+playwright-cli eval "el => el.id" e7
+
+# get all CSS classes
+playwright-cli eval "el => el.className" e7
+
+# get a specific attribute
+playwright-cli eval "el => el.getAttribute('data-testid')" e7
+playwright-cli eval "el => el.getAttribute('aria-label')" e7
+
+# get a computed style property
+playwright-cli eval "el => getComputedStyle(el).display" e7
+```

--- a/.claude/skills/playwright-cli/references/playwright-tests.md
+++ b/.claude/skills/playwright-cli/references/playwright-tests.md
@@ -1,0 +1,39 @@
+# Running Playwright Tests
+
+To run Playwright tests, use the `npx playwright test` command, or a package manager script. To avoid opening the interactive html report, use `PLAYWRIGHT_HTML_OPEN=never` environment variable.
+
+```bash
+# Run all tests
+PLAYWRIGHT_HTML_OPEN=never npx playwright test
+
+# Run all tests through a custom npm script
+PLAYWRIGHT_HTML_OPEN=never npm run special-test-command
+```
+
+# Debugging Playwright Tests
+
+To debug a failing Playwright test, run it with `--debug=cli` option. This command will pause the test at the start and print the debugging instructions.
+
+**IMPORTANT**: run the command in the background and check the output until "Debugging Instructions" is printed.
+
+Once instructions containing a session name are printed, use `playwright-cli` to attach the session and explore the page.
+
+```bash
+# Run the test
+PLAYWRIGHT_HTML_OPEN=never npx playwright test --debug=cli
+# ...
+# ... debugging instructions for "tw-abcdef" session ...
+# ...
+
+# Attach to the test
+playwright-cli attach tw-abcdef
+```
+
+Keep the test running in the background while you explore and look for a fix.
+The test is paused at the start, so you should step over or pause at a particular location
+where the problem is most likely to be.
+
+Every action you perform with `playwright-cli` generates corresponding Playwright TypeScript code.
+This code appears in the output and can be copied directly into the test. Most of the time, a specific locator or an expectation should be updated, but it could also be a bug in the app. Use your judgement.
+
+After fixing the test, stop the background test run. Rerun to check that test passes.

--- a/.claude/skills/playwright-cli/references/request-mocking.md
+++ b/.claude/skills/playwright-cli/references/request-mocking.md
@@ -1,0 +1,87 @@
+# Request Mocking
+
+Intercept, mock, modify, and block network requests.
+
+## CLI Route Commands
+
+```bash
+# Mock with custom status
+playwright-cli route "**/*.jpg" --status=404
+
+# Mock with JSON body
+playwright-cli route "**/api/users" --body='[{"id":1,"name":"Alice"}]' --content-type=application/json
+
+# Mock with custom headers
+playwright-cli route "**/api/data" --body='{"ok":true}' --header="X-Custom: value"
+
+# Remove headers from requests
+playwright-cli route "**/*" --remove-header=cookie,authorization
+
+# List active routes
+playwright-cli route-list
+
+# Remove a route or all routes
+playwright-cli unroute "**/*.jpg"
+playwright-cli unroute
+```
+
+## URL Patterns
+
+```
+**/api/users           - Exact path match
+**/api/*/details       - Wildcard in path
+**/*.{png,jpg,jpeg}    - Match file extensions
+**/search?q=*          - Match query parameters
+```
+
+## Advanced Mocking with run-code
+
+For conditional responses, request body inspection, response modification, or delays:
+
+### Conditional Response Based on Request
+
+```bash
+playwright-cli run-code "async page => {
+  await page.route('**/api/login', route => {
+    const body = route.request().postDataJSON();
+    if (body.username === 'admin') {
+      route.fulfill({ body: JSON.stringify({ token: 'mock-token' }) });
+    } else {
+      route.fulfill({ status: 401, body: JSON.stringify({ error: 'Invalid' }) });
+    }
+  });
+}"
+```
+
+### Modify Real Response
+
+```bash
+playwright-cli run-code "async page => {
+  await page.route('**/api/user', async route => {
+    const response = await route.fetch();
+    const json = await response.json();
+    json.isPremium = true;
+    await route.fulfill({ response, json });
+  });
+}"
+```
+
+### Simulate Network Failures
+
+```bash
+playwright-cli run-code "async page => {
+  await page.route('**/api/offline', route => route.abort('internetdisconnected'));
+}"
+# Options: connectionrefused, timedout, connectionreset, internetdisconnected
+```
+
+### Delayed Response
+
+```bash
+playwright-cli run-code "async page => {
+  await page.route('**/api/slow', async route => {
+    await new Promise(r => setTimeout(r, 3000));
+    route.fulfill({ body: JSON.stringify({ data: 'loaded' }) });
+  });
+}"
+```

--- a/.claude/skills/playwright-cli/references/running-code.md
+++ b/.claude/skills/playwright-cli/references/running-code.md
@@ -1,0 +1,231 @@
+# Running Custom Playwright Code
+
+Use `run-code` to execute arbitrary Playwright code for advanced scenarios not covered by CLI commands.
+
+## Syntax
+
+```bash
+playwright-cli run-code "async page => {
+  // Your Playwright code here
+  // Access page.context() for browser context operations
+}"
+```
+
+## Geolocation
+
+```bash
+# Grant geolocation permission and set location
+playwright-cli run-code "async page => {
+  await page.context().grantPermissions(['geolocation']);
+  await page.context().setGeolocation({ latitude: 37.7749, longitude: -122.4194 });
+}"
+
+# Set location to London
+playwright-cli run-code "async page => {
+  await page.context().grantPermissions(['geolocation']);
+  await page.context().setGeolocation({ latitude: 51.5074, longitude: -0.1278 });
+}"
+
+# Clear geolocation override
+playwright-cli run-code "async page => {
+  await page.context().clearPermissions();
+}"
+```
+
+## Permissions
+
+```bash
+# Grant multiple permissions
+playwright-cli run-code "async page => {
+  await page.context().grantPermissions([
+    'geolocation',
+    'notifications',
+    'camera',
+    'microphone'
+  ]);
+}"
+
+# Grant permissions for specific origin
+playwright-cli run-code "async page => {
+  await page.context().grantPermissions(['clipboard-read'], {
+    origin: 'https://example.com'
+  });
+}"
+```
+
+## Media Emulation
+
+```bash
+# Emulate dark color scheme
+playwright-cli run-code "async page => {
+  await page.emulateMedia({ colorScheme: 'dark' });
+}"
+
+# Emulate light color scheme
+playwright-cli run-code "async page => {
+  await page.emulateMedia({ colorScheme: 'light' });
+}"
+
+# Emulate reduced motion
+playwright-cli run-code "async page => {
+  await page.emulateMedia({ reducedMotion: 'reduce' });
+}"
+
+# Emulate print media
+playwright-cli run-code "async page => {
+  await page.emulateMedia({ media: 'print' });
+}"
+```
+
+## Wait Strategies
+
+```bash
+# Wait for network idle
+playwright-cli run-code "async page => {
+  await page.waitForLoadState('networkidle');
+}"
+
+# Wait for specific element
+playwright-cli run-code "async page => {
+  await page.locator('.loading').waitFor({ state: 'hidden' });
+}"
+
+# Wait for function to return true
+playwright-cli run-code "async page => {
+  await page.waitForFunction(() => window.appReady === true);
+}"
+
+# Wait with timeout
+playwright-cli run-code "async page => {
+  await page.locator('.result').waitFor({ timeout: 10000 });
+}"
+```
+
+## Frames and Iframes
+
+```bash
+# Work with iframe
+playwright-cli run-code "async page => {
+  const frame = page.locator('iframe#my-iframe').contentFrame();
+  await frame.locator('button').click();
+}"
+
+# Get all frames
+playwright-cli run-code "async page => {
+  const frames = page.frames();
+  return frames.map(f => f.url());
+}"
+```
+
+## File Downloads
+
+```bash
+# Handle file download
+playwright-cli run-code "async page => {
+  const downloadPromise = page.waitForEvent('download');
+  await page.getByRole('link', { name: 'Download' }).click();
+  const download = await downloadPromise;
+  await download.saveAs('./downloaded-file.pdf');
+  return download.suggestedFilename();
+}"
+```
+
+## Clipboard
+
+```bash
+# Read clipboard (requires permission)
+playwright-cli run-code "async page => {
+  await page.context().grantPermissions(['clipboard-read']);
+  return await page.evaluate(() => navigator.clipboard.readText());
+}"
+
+# Write to clipboard
+playwright-cli run-code "async page => {
+  await page.evaluate(text => navigator.clipboard.writeText(text), 'Hello clipboard!');
+}"
+```
+
+## Page Information
+
+```bash
+# Get page title
+playwright-cli run-code "async page => {
+  return await page.title();
+}"
+
+# Get current URL
+playwright-cli run-code "async page => {
+  return page.url();
+}"
+
+# Get page content
+playwright-cli run-code "async page => {
+  return await page.content();
+}"
+
+# Get viewport size
+playwright-cli run-code "async page => {
+  return page.viewportSize();
+}"
+```
+
+## JavaScript Execution
+
+```bash
+# Execute JavaScript and return result
+playwright-cli run-code "async page => {
+  return await page.evaluate(() => {
+    return {
+      userAgent: navigator.userAgent,
+      language: navigator.language,
+      cookiesEnabled: navigator.cookieEnabled
+    };
+  });
+}"
+
+# Pass arguments to evaluate
+playwright-cli run-code "async page => {
+  const multiplier = 5;
+  return await page.evaluate(m => document.querySelectorAll('li').length * m, multiplier);
+}"
+```
+
+## Error Handling
+
+```bash
+# Try-catch in run-code
+playwright-cli run-code "async page => {
+  try {
+    await page.getByRole('button', { name: 'Submit' }).click({ timeout: 1000 });
+    return 'clicked';
+  } catch (e) {
+    return 'element not found';
+  }
+}"
+```
+
+## Complex Workflows
+
+```bash
+# Login and save state
+playwright-cli run-code "async page => {
+  await page.goto('https://example.com/login');
+  await page.getByRole('textbox', { name: 'Email' }).fill('user@example.com');
+  await page.getByRole('textbox', { name: 'Password' }).fill('secret');
+  await page.getByRole('button', { name: 'Sign in' }).click();
+  await page.waitForURL('**/dashboard');
+  await page.context().storageState({ path: 'auth.json' });
+  return 'Login successful';
+}"
+
+# Scrape data from multiple pages
+playwright-cli run-code "async page => {
+  const results = [];
+  for (let i = 1; i <= 3; i++) {
+    await page.goto(\`https://example.com/page/\${i}\`);
+    const items = await page.locator('.item').allTextContents();
+    results.push(...items);
+  }
+  return results;
+}"
+```

--- a/.claude/skills/playwright-cli/references/session-management.md
+++ b/.claude/skills/playwright-cli/references/session-management.md
@@ -1,0 +1,169 @@
+# Browser Session Management
+
+Run multiple isolated browser sessions concurrently with state persistence.
+
+## Named Browser Sessions
+
+Use `-s` flag to isolate browser contexts:
+
+```bash
+# Browser 1: Authentication flow
+playwright-cli -s=auth open https://app.example.com/login
+
+# Browser 2: Public browsing (separate cookies, storage)
+playwright-cli -s=public open https://example.com
+
+# Commands are isolated by browser session
+playwright-cli -s=auth fill e1 "user@example.com"
+playwright-cli -s=public snapshot
+```
+
+## Browser Session Isolation Properties
+
+Each browser session has independent:
+- Cookies
+- LocalStorage / SessionStorage
+- IndexedDB
+- Cache
+- Browsing history
+- Open tabs
+
+## Browser Session Commands
+
+```bash
+# List all browser sessions
+playwright-cli list
+
+# Stop a browser session (close the browser)
+playwright-cli close                # stop the default browser
+playwright-cli -s=mysession close   # stop a named browser
+
+# Stop all browser sessions
+playwright-cli close-all
+
+# Forcefully kill all daemon processes (for stale/zombie processes)
+playwright-cli kill-all
+
+# Delete browser session user data (profile directory)
+playwright-cli delete-data                # delete default browser data
+playwright-cli -s=mysession delete-data   # delete named browser data
+```
+
+## Environment Variable
+
+Set a default browser session name via environment variable:
+
+```bash
+export PLAYWRIGHT_CLI_SESSION="mysession"
+playwright-cli open example.com  # Uses "mysession" automatically
+```
+
+## Common Patterns
+
+### Concurrent Scraping
+
+```bash
+#!/bin/bash
+# Scrape multiple sites concurrently
+
+# Start all browsers
+playwright-cli -s=site1 open https://site1.com &
+playwright-cli -s=site2 open https://site2.com &
+playwright-cli -s=site3 open https://site3.com &
+wait
+
+# Take snapshots from each
+playwright-cli -s=site1 snapshot
+playwright-cli -s=site2 snapshot
+playwright-cli -s=site3 snapshot
+
+# Cleanup
+playwright-cli close-all
+```
+
+### A/B Testing Sessions
+
+```bash
+# Test different user experiences
+playwright-cli -s=variant-a open "https://app.com?variant=a"
+playwright-cli -s=variant-b open "https://app.com?variant=b"
+
+# Compare
+playwright-cli -s=variant-a screenshot
+playwright-cli -s=variant-b screenshot
+```
+
+### Persistent Profile
+
+By default, browser profile is kept in memory only. Use `--persistent` flag on `open` to persist the browser profile to disk:
+
+```bash
+# Use persistent profile (auto-generated location)
+playwright-cli open https://example.com --persistent
+
+# Use persistent profile with custom directory
+playwright-cli open https://example.com --profile=/path/to/profile
+```
+
+## Default Browser Session
+
+When `-s` is omitted, commands use the default browser session:
+
+```bash
+# These use the same default browser session
+playwright-cli open https://example.com
+playwright-cli snapshot
+playwright-cli close  # Stops default browser
+```
+
+## Browser Session Configuration
+
+Configure a browser session with specific settings when opening:
+
+```bash
+# Open with config file
+playwright-cli open https://example.com --config=.playwright/my-cli.json
+
+# Open with specific browser
+playwright-cli open https://example.com --browser=firefox
+
+# Open in headed mode
+playwright-cli open https://example.com --headed
+
+# Open with persistent profile
+playwright-cli open https://example.com --persistent
+```
+
+## Best Practices
+
+### 1. Name Browser Sessions Semantically
+
+```bash
+# GOOD: Clear purpose
+playwright-cli -s=github-auth open https://github.com
+playwright-cli -s=docs-scrape open https://docs.example.com
+
+# AVOID: Generic names
+playwright-cli -s=s1 open https://github.com
+```
+
+### 2. Always Clean Up
+
+```bash
+# Stop browsers when done
+playwright-cli -s=auth close
+playwright-cli -s=scrape close
+
+# Or stop all at once
+playwright-cli close-all
+
+# If browsers become unresponsive or zombie processes remain
+playwright-cli kill-all
+```
+
+### 3. Delete Stale Browser Data
+
+```bash
+# Remove old browser data to free disk space
+playwright-cli -s=oldsession delete-data
+```

--- a/.claude/skills/playwright-cli/references/storage-state.md
+++ b/.claude/skills/playwright-cli/references/storage-state.md
@@ -1,0 +1,275 @@
+# Storage Management
+
+Manage cookies, localStorage, sessionStorage, and browser storage state.
+
+## Storage State
+
+Save and restore complete browser state including cookies and storage.
+
+### Save Storage State
+
+```bash
+# Save to auto-generated filename (storage-state-{timestamp}.json)
+playwright-cli state-save
+
+# Save to specific filename
+playwright-cli state-save my-auth-state.json
+```
+
+### Restore Storage State
+
+```bash
+# Load storage state from file
+playwright-cli state-load my-auth-state.json
+
+# Reload page to apply cookies
+playwright-cli open https://example.com
+```
+
+### Storage State File Format
+
+The saved file contains:
+
+```json
+{
+  "cookies": [
+    {
+      "name": "session_id",
+      "value": "abc123",
+      "domain": "example.com",
+      "path": "/",
+      "expires": 1735689600,
+      "httpOnly": true,
+      "secure": true,
+      "sameSite": "Lax"
+    }
+  ],
+  "origins": [
+    {
+      "origin": "https://example.com",
+      "localStorage": [
+        { "name": "theme", "value": "dark" },
+        { "name": "user_id", "value": "12345" }
+      ]
+    }
+  ]
+}
+```
+
+## Cookies
+
+### List All Cookies
+
+```bash
+playwright-cli cookie-list
+```
+
+### Filter Cookies by Domain
+
+```bash
+playwright-cli cookie-list --domain=example.com
+```
+
+### Filter Cookies by Path
+
+```bash
+playwright-cli cookie-list --path=/api
+```
+
+### Get Specific Cookie
+
+```bash
+playwright-cli cookie-get session_id
+```
+
+### Set a Cookie
+
+```bash
+# Basic cookie
+playwright-cli cookie-set session abc123
+
+# Cookie with options
+playwright-cli cookie-set session abc123 --domain=example.com --path=/ --httpOnly --secure --sameSite=Lax
+
+# Cookie with expiration (Unix timestamp)
+playwright-cli cookie-set remember_me token123 --expires=1735689600
+```
+
+### Delete a Cookie
+
+```bash
+playwright-cli cookie-delete session_id
+```
+
+### Clear All Cookies
+
+```bash
+playwright-cli cookie-clear
+```
+
+### Advanced: Multiple Cookies or Custom Options
+
+For complex scenarios like adding multiple cookies at once, use `run-code`:
+
+```bash
+playwright-cli run-code "async page => {
+  await page.context().addCookies([
+    { name: 'session_id', value: 'sess_abc123', domain: 'example.com', path: '/', httpOnly: true },
+    { name: 'preferences', value: JSON.stringify({ theme: 'dark' }), domain: 'example.com', path: '/' }
+  ]);
+}"
+```
+
+## Local Storage
+
+### List All localStorage Items
+
+```bash
+playwright-cli localstorage-list
+```
+
+### Get Single Value
+
+```bash
+playwright-cli localstorage-get token
+```
+
+### Set Value
+
+```bash
+playwright-cli localstorage-set theme dark
+```
+
+### Set JSON Value
+
+```bash
+playwright-cli localstorage-set user_settings '{"theme":"dark","language":"en"}'
+```
+
+### Delete Single Item
+
+```bash
+playwright-cli localstorage-delete token
+```
+
+### Clear All localStorage
+
+```bash
+playwright-cli localstorage-clear
+```
+
+### Advanced: Multiple Operations
+
+For complex scenarios like setting multiple values at once, use `run-code`:
+
+```bash
+playwright-cli run-code "async page => {
+  await page.evaluate(() => {
+    localStorage.setItem('token', 'jwt_abc123');
+    localStorage.setItem('user_id', '12345');
+    localStorage.setItem('expires_at', Date.now() + 3600000);
+  });
+}"
+```
+
+## Session Storage
+
+### List All sessionStorage Items
+
+```bash
+playwright-cli sessionstorage-list
+```
+
+### Get Single Value
+
+```bash
+playwright-cli sessionstorage-get form_data
+```
+
+### Set Value
+
+```bash
+playwright-cli sessionstorage-set step 3
+```
+
+### Delete Single Item
+
+```bash
+playwright-cli sessionstorage-delete step
+```
+
+### Clear sessionStorage
+
+```bash
+playwright-cli sessionstorage-clear
+```
+
+## IndexedDB
+
+### List Databases
+
+```bash
+playwright-cli run-code "async page => {
+  return await page.evaluate(async () => {
+    const databases = await indexedDB.databases();
+    return databases;
+  });
+}"
+```
+
+### Delete Database
+
+```bash
+playwright-cli run-code "async page => {
+  await page.evaluate(() => {
+    indexedDB.deleteDatabase('myDatabase');
+  });
+}"
+```
+
+## Common Patterns
+
+### Authentication State Reuse
+
+```bash
+# Step 1: Login and save state
+playwright-cli open https://app.example.com/login
+playwright-cli snapshot
+playwright-cli fill e1 "user@example.com"
+playwright-cli fill e2 "password123"
+playwright-cli click e3
+
+# Save the authenticated state
+playwright-cli state-save auth.json
+
+# Step 2: Later, restore state and skip login
+playwright-cli state-load auth.json
+playwright-cli open https://app.example.com/dashboard
+# Already logged in!
+```
+
+### Save and Restore Roundtrip
+
+```bash
+# Set up authentication state
+playwright-cli open https://example.com
+playwright-cli eval "() => { document.cookie = 'session=abc123'; localStorage.setItem('user', 'john'); }"
+
+# Save state to file
+playwright-cli state-save my-session.json
+
+# ... later, in a new session ...
+
+# Restore state
+playwright-cli state-load my-session.json
+playwright-cli open https://example.com
+# Cookies and localStorage are restored!
+```
+
+## Security Notes
+
+- Never commit storage state files containing auth tokens
+- Add `*.auth-state.json` to `.gitignore`
+- Delete state files after automation completes
+- Use environment variables for sensitive data
+- By default, sessions run in-memory mode which is safer for sensitive operations

--- a/.claude/skills/playwright-cli/references/test-generation.md
+++ b/.claude/skills/playwright-cli/references/test-generation.md
@@ -1,0 +1,88 @@
+# Test Generation
+
+Generate Playwright test code automatically as you interact with the browser.
+
+## How It Works
+
+Every action you perform with `playwright-cli` generates corresponding Playwright TypeScript code.
+This code appears in the output and can be copied directly into your test files.
+
+## Example Workflow
+
+```bash
+# Start a session
+playwright-cli open https://example.com/login
+
+# Take a snapshot to see elements
+playwright-cli snapshot
+# Output shows: e1 [textbox "Email"], e2 [textbox "Password"], e3 [button "Sign In"]
+
+# Fill form fields - generates code automatically
+playwright-cli fill e1 "user@example.com"
+# Ran Playwright code:
+# await page.getByRole('textbox', { name: 'Email' }).fill('user@example.com');
+
+playwright-cli fill e2 "password123"
+# Ran Playwright code:
+# await page.getByRole('textbox', { name: 'Password' }).fill('password123');
+
+playwright-cli click e3
+# Ran Playwright code:
+# await page.getByRole('button', { name: 'Sign In' }).click();
+```
+
+## Building a Test File
+
+Collect the generated code into a Playwright test:
+
+```typescript
+import { test, expect } from '@playwright/test';
+
+test('login flow', async ({ page }) => {
+  // Generated code from playwright-cli session:
+  await page.goto('https://example.com/login');
+  await page.getByRole('textbox', { name: 'Email' }).fill('user@example.com');
+  await page.getByRole('textbox', { name: 'Password' }).fill('password123');
+  await page.getByRole('button', { name: 'Sign In' }).click();
+
+  // Add assertions
+  await expect(page).toHaveURL(/.*dashboard/);
+});
+```
+
+## Best Practices
+
+### 1. Use Semantic Locators
+
+The generated code uses role-based locators when possible, which are more resilient:
+
+```typescript
+// Generated (good - semantic)
+await page.getByRole('button', { name: 'Submit' }).click();
+
+// Avoid (fragile - CSS selectors)
+await page.locator('#submit-btn').click();
+```
+
+### 2. Explore Before Recording
+
+Take snapshots to understand the page structure before recording actions:
+
+```bash
+playwright-cli open https://example.com
+playwright-cli snapshot
+# Review the element structure
+playwright-cli click e5
+```
+
+### 3. Add Assertions Manually
+
+Generated code captures actions but not assertions. Add expectations in your test:
+
+```typescript
+// Generated action
+await page.getByRole('button', { name: 'Submit' }).click();
+
+// Manual assertion
+await expect(page.getByText('Success')).toBeVisible();
+```

--- a/.claude/skills/playwright-cli/references/tracing.md
+++ b/.claude/skills/playwright-cli/references/tracing.md
@@ -1,0 +1,139 @@
+# Tracing
+
+Capture detailed execution traces for debugging and analysis. Traces include DOM snapshots, screenshots, network activity, and console logs.
+
+## Basic Usage
+
+```bash
+# Start trace recording
+playwright-cli tracing-start
+
+# Perform actions
+playwright-cli open https://example.com
+playwright-cli click e1
+playwright-cli fill e2 "test"
+
+# Stop trace recording
+playwright-cli tracing-stop
+```
+
+## Trace Output Files
+
+When you start tracing, Playwright creates a `traces/` directory with several files:
+
+### `trace-{timestamp}.trace`
+
+**Action log** - The main trace file containing:
+- Every action performed (clicks, fills, navigations)
+- DOM snapshots before and after each action
+- Screenshots at each step
+- Timing information
+- Console messages
+- Source locations
+
+### `trace-{timestamp}.network`
+
+**Network log** - Complete network activity:
+- All HTTP requests and responses
+- Request headers and bodies
+- Response headers and bodies
+- Timing (DNS, connect, TLS, TTFB, download)
+- Resource sizes
+- Failed requests and errors
+
+### `resources/`
+
+**Resources directory** - Cached resources:
+- Images, fonts, stylesheets, scripts
+- Response bodies for replay
+- Assets needed to reconstruct page state
+
+## What Traces Capture
+
+| Category | Details |
+|----------|---------|
+| **Actions** | Clicks, fills, hovers, keyboard input, navigations |
+| **DOM** | Full DOM snapshot before/after each action |
+| **Screenshots** | Visual state at each step |
+| **Network** | All requests, responses, headers, bodies, timing |
+| **Console** | All console.log, warn, error messages |
+| **Timing** | Precise timing for each operation |
+
+## Use Cases
+
+### Debugging Failed Actions
+
+```bash
+playwright-cli tracing-start
+playwright-cli open https://app.example.com
+
+# This click fails - why?
+playwright-cli click e5
+
+playwright-cli tracing-stop
+# Open trace to see DOM state when click was attempted
+```
+
+### Analyzing Performance
+
+```bash
+playwright-cli tracing-start
+playwright-cli open https://slow-site.com
+playwright-cli tracing-stop
+
+# View network waterfall to identify slow resources
+```
+
+### Capturing Evidence
+
+```bash
+# Record a complete user flow for documentation
+playwright-cli tracing-start
+
+playwright-cli open https://app.example.com/checkout
+playwright-cli fill e1 "4111111111111111"
+playwright-cli fill e2 "12/25"
+playwright-cli fill e3 "123"
+playwright-cli click e4
+
+playwright-cli tracing-stop
+# Trace shows exact sequence of events
+```
+
+## Trace vs Video vs Screenshot
+
+| Feature | Trace | Video | Screenshot |
+|---------|-------|-------|------------|
+| **Format** | .trace file | .webm video | .png/.jpeg image |
+| **DOM inspection** | Yes | No | No |
+| **Network details** | Yes | No | No |
+| **Step-by-step replay** | Yes | Continuous | Single frame |
+| **File size** | Medium | Large | Small |
+| **Best for** | Debugging | Demos | Quick capture |
+
+## Best Practices
+
+### 1. Start Tracing Before the Problem
+
+```bash
+# Trace the entire flow, not just the failing step
+playwright-cli tracing-start
+playwright-cli open https://example.com
+# ... all steps leading to the issue ...
+playwright-cli tracing-stop
+```
+
+### 2. Clean Up Old Traces
+
+Traces can consume significant disk space:
+
+```bash
+# Remove traces older than 7 days
+find .playwright-cli/traces -mtime +7 -delete
+```
+
+## Limitations
+
+- Traces add overhead to automation
+- Large traces can consume significant disk space
+- Some dynamic content may not replay perfectly

--- a/.claude/skills/playwright-cli/references/video-recording.md
+++ b/.claude/skills/playwright-cli/references/video-recording.md
@@ -1,0 +1,143 @@
+# Video Recording
+
+Capture browser automation sessions as video for debugging, documentation, or verification. Produces WebM (VP8/VP9 codec).
+
+## Basic Recording
+
+```bash
+# Open browser first
+playwright-cli open
+
+# Start recording
+playwright-cli video-start demo.webm
+
+# Add a chapter marker for section transitions
+playwright-cli video-chapter "Getting Started" --description="Opening the homepage" --duration=2000
+
+# Navigate and perform actions
+playwright-cli goto https://example.com
+playwright-cli snapshot
+playwright-cli click e1
+
+# Add another chapter
+playwright-cli video-chapter "Filling Form" --description="Entering test data" --duration=2000
+playwright-cli fill e2 "test input"
+
+# Stop and save
+playwright-cli video-stop
+```
+
+## Best Practices
+
+### 1. Use Descriptive Filenames
+
+```bash
+# Include context in filename
+playwright-cli video-start recordings/login-flow-2024-01-15.webm
+playwright-cli video-start recordings/checkout-test-run-42.webm
+```
+
+### 2. Record entire hero scripts.
+
+When recording a video for the user or as a proof of work, it is best to create a code snippet and execute it with run-code.
+It allows pulling appropriate pauses between the actions and annotating the video. There are new Playwright APIs for that.
+
+1) Perform scenario using CLI and take note of all locators and actions. You'll need those locators to request thier bounding boxes for highlight.
+2) Create a file with the intended script for video (below). Use pressSequentially w/ delay for nice typing, make reasonable pauses.
+3) Use playwright-cli run-code --file your-script.js
+
+**Important**: Overlays are `pointer-events: none` — they do not interfere with page interactions. You can safely keep sticky overlays visible while clicking, filling, or performing any actions on the page.
+
+```js
+async page => {
+  await page.screencast.start({ path: 'video.webm', size: { width: 1280, height: 800 } });
+  await page.goto('https://demo.playwright.dev/todomvc');
+
+  // Show a chapter card — blurs the page and shows a dialog.
+  // Blocks until duration expires, then auto-removes.
+  // Use this for simple use cases, but always feel free to hand-craft your own beautiful
+  // overlay via await page.screencast.showOverlay().
+  await page.screencast.showChapter('Adding Todo Items', {
+    description: 'We will add several items to the todo list.',
+    duration: 2000,
+  });
+
+  // Perform action
+  await page.getByRole('textbox', { name: 'What needs to be done?' }).pressSequentially('Walk the dog', { delay: 60 });
+  await page.getByRole('textbox', { name: 'What needs to be done?' }).press('Enter');
+  await page.waitForTimeout(1000);
+
+  // Show next chapter
+  await page.screencast.showChapter('Verifying Results', {
+    description: 'Checking the item appeared in the list.',
+    duration: 2000,
+  });
+
+  // Add a sticky annotation that stays while you perform actions.
+  // Overlays are pointer-events: none, so they won't block clicks.
+  const annotation = await page.screencast.showOverlay(`
+    <div style="position: absolute; top: 8px; right: 8px;
+      padding: 6px 12px; background: rgba(0,0,0,0.7);
+      border-radius: 8px; font-size: 13px; color: white;">
+      ✓ Item added successfully
+    </div>
+  `);
+
+  // Perform more actions while the annotation is visible
+  await page.getByRole('textbox', { name: 'What needs to be done?' }).pressSequentially('Buy groceries', { delay: 60 });
+  await page.getByRole('textbox', { name: 'What needs to be done?' }).press('Enter');
+  await page.waitForTimeout(1500);
+
+  // Remove the annotation when done
+  await annotation.dispose();
+
+  // You can also highlight relevant locators and provide contextual annotations.
+  const bounds = await page.getByText('Walk the dog').boundingBox();
+  await page.screencast.showOverlay(`
+    <div style="position: absolute;
+      top: ${bounds.y}px;
+      left: ${bounds.x}px;
+      width: ${bounds.width}px;
+      height: ${bounds.height}px;
+      border: 1px solid red;">
+    </div>
+    <div style="position: absolute;
+      top: ${bounds.y + bounds.height + 5}px;
+      left: ${bounds.x + bounds.width / 2}px;
+      transform: translateX(-50%);
+      padding: 6px;
+      background: #808080;
+      border-radius: 10px;
+      font-size: 14px;
+      color: white;">Check it out, it is right above this text
+    </div>
+  `, { duration: 2000 });
+
+  await page.screencast.stop();
+}
+```
+
+Embrace creativity, overlays are powerful.
+
+### Overlay API Summary
+
+| Method | Use Case |
+|--------|----------|
+| `page.screencast.showChapter(title, { description?, duration?, styleSheet? })` | Full-screen chapter card with blurred backdrop — ideal for section transitions |
+| `page.screencast.showOverlay(html, { duration? })` | Custom HTML overlay — use for callouts, labels, highlights |
+| `disposable.dispose()` | Remove a sticky overlay added without duration |
+| `page.screencast.hideOverlays()` / `page.screencast.showOverlays()` | Temporarily hide/show all overlays |
+
+## Tracing vs Video
+
+| Feature | Video | Tracing |
+|---------|-------|---------|
+| Output | WebM file | Trace file (viewable in Trace Viewer) |
+| Shows | Visual recording | DOM snapshots, network, console, actions |
+| Use case | Demos, documentation | Debugging, analysis |
+| Size | Larger | Smaller |
+
+## Limitations
+
+- Recording adds slight overhead to automation
+- Large recordings can consume significant disk space

--- a/.github/skills/cypress-cli/SKILL.md
+++ b/.github/skills/cypress-cli/SKILL.md
@@ -1,0 +1,316 @@
+---
+name: cypress-cli
+description: Interact with live web pages through Cypress commands via the cypress-cli tool
+user-invocable: true
+---
+
+# cypress-cli Skill
+
+## What this skill does
+
+This skill teaches you how to use the `cypress-cli` tool to interact with live
+web pages through real Cypress commands. Use it to open pages, inspect aria
+snapshots, interact with elements, inspect browser state, export Cypress tests,
+and run targeted browser or Cypress code.
+
+## When to use this skill
+
+- When you need to open a web page and inspect its DOM
+- When you need to interact with elements (click, type, check, select, etc.)
+- When you need to assert element state
+- When you need cookies, localStorage, sessionStorage, or saved browser state
+- When you need network inspection or request mocking
+- When you need browser console output or screenshots
+- When you need to generate Cypress test code from a session
+- When you need to execute browser-side JavaScript or Cypress chain code
+
+## Output format
+
+Most page-oriented commands return output like this:
+
+```text
+### Page
+- Page URL: https://example.com
+- Page Title: Example
+### Snapshot
+[Snapshot](.cypress-cli/page-2026-04-10T19-22-42-679Z.yml)
+```
+
+Structured-data commands such as `console`, `network`, `history`, storage
+commands, and `run` return JSON-like data or summaries instead of a snapshot.
+
+## Commands
+
+### Core
+
+| Command | Example | Purpose |
+| ------- | ------- | ------- |
+| `open` | `cypress-cli open https://example.com` | Start or reuse a session and navigate to a URL |
+| `repl` | `cypress-cli repl` | Start interactive REPL mode for an existing session |
+| `snapshot` | `cypress-cli snapshot` | Capture the current aria snapshot |
+| `status` | `cypress-cli status` | Show session status and metadata |
+| `install` | `cypress-cli install --skills` | Install the bundled skill into `.github/skills/cypress-cli` |
+| `stop` | `cypress-cli stop` | Stop the active session |
+
+### Navigation
+
+| Command | Example | Purpose |
+| ------- | ------- | ------- |
+| `navigate` | `cypress-cli navigate https://example.com/dashboard` | Visit a new URL in the current session |
+| `back` | `cypress-cli back` | Go back in browser history |
+| `forward` | `cypress-cli forward` | Go forward in browser history |
+| `reload` | `cypress-cli reload` | Reload the current page |
+
+### Interaction
+
+| Command | Example | Purpose |
+| ------- | ------- | ------- |
+| `click` | `cypress-cli click e5` | Click an element by ref |
+| `dblclick` | `cypress-cli dblclick e5` | Double-click an element by ref |
+| `rightclick` | `cypress-cli rightclick e5` | Right-click an element by ref |
+| `type` | `cypress-cli type e12 'hello'` | Type text into an element |
+| `fill` | `cypress-cli fill e12 'full replacement text'` | Clear and replace text in an element |
+| `clear` | `cypress-cli clear e12` | Clear an input element |
+| `check` | `cypress-cli check e8` | Check a checkbox or radio input |
+| `uncheck` | `cypress-cli uncheck e8` | Uncheck a checkbox |
+| `select` | `cypress-cli select e15 'Option A'` | Select an option from a `<select>` |
+| `focus` | `cypress-cli focus e12` | Focus an element |
+| `blur` | `cypress-cli blur e12` | Blur an element |
+| `scrollto` | `cypress-cli scrollto e3` | Scroll an element into view or scroll to a position |
+| `hover` | `cypress-cli hover e7` | Trigger hover on an element |
+| `drag` | `cypress-cli drag e3 e7` | Drag one element onto another |
+| `upload` | `cypress-cli upload e10 ./file.pdf` | Upload a file through a file input |
+| `dialog-accept` | `cypress-cli dialog-accept` | Accept the next browser dialog |
+| `dialog-dismiss` | `cypress-cli dialog-dismiss` | Dismiss the next browser dialog |
+| `resize` | `cypress-cli resize 1280 720` | Change the browser viewport size |
+
+### Keyboard
+
+| Command | Example | Purpose |
+| ------- | ------- | ------- |
+| `press` | `cypress-cli press Enter` | Send a keyboard key to the page |
+
+### Assertion
+
+| Command | Example | Purpose |
+| ------- | ------- | ------- |
+| `assert` | `cypress-cli assert e5 have.text 'Submit'` | Assert on an element |
+| `asserturl` | `cypress-cli asserturl include '/dashboard'` | Assert on the current URL |
+| `asserttitle` | `cypress-cli asserttitle eq 'Home'` | Assert on the page title |
+
+### Wait
+
+| Command | Example | Purpose |
+| ------- | ------- | ------- |
+| `wait` | `cypress-cli wait 1000` | Wait a fixed number of milliseconds |
+| `waitfor` | `cypress-cli waitfor e12` | Wait for an element to exist |
+
+### Execution
+
+| Command | Example | Purpose |
+| ------- | ------- | ------- |
+| `run-code` | `cypress-cli run-code "document.querySelectorAll('input').length"` | Execute browser-side JavaScript in the page context |
+| `eval` | `cypress-cli eval "document.title"` | Evaluate a JavaScript expression on the page or on a specific ref |
+| `cyrun` | `cypress-cli cyrun "cy.url().then(u => u)"` | Execute Cypress chain code in the Cypress runner context |
+| `run` | `cypress-cli run ./generated.cy.ts` | Run a Cypress spec file and report structured results |
+
+### Export and history
+
+| Command | Example | Purpose |
+| ------- | ------- | ------- |
+| `export` | `cypress-cli export --file ./generated.cy.ts` | Export session history as a Cypress test file |
+| `history` | `cypress-cli history` | Show commands recorded for export |
+| `undo` | `cypress-cli undo` | Remove the last command from export history |
+
+### Network
+
+| Command | Example | Purpose |
+| ------- | ------- | ------- |
+| `intercept` | `cypress-cli intercept '**/api/users' --status 200 --body '{"users":[]}'` | Register a request intercept or mock response |
+| `waitforresponse` | `cypress-cli waitforresponse '**/api/users'` | Wait for a previously intercepted response |
+| `unintercept` | `cypress-cli unintercept '**/api/users'` | Remove one intercept or all intercepts |
+| `intercept-list` | `cypress-cli intercept-list` | List active intercepts |
+| `network` | `cypress-cli network` | Show captured network requests |
+
+### Cookies
+
+| Command | Example | Purpose |
+| ------- | ------- | ------- |
+| `cookie-list` | `cypress-cli cookie-list` | List cookies |
+| `cookie-get` | `cypress-cli cookie-get session_id` | Read a cookie by name |
+| `cookie-set` | `cypress-cli cookie-set theme dark` | Set a cookie |
+| `cookie-delete` | `cypress-cli cookie-delete session_id` | Delete a cookie by name |
+| `cookie-clear` | `cypress-cli cookie-clear` | Clear all cookies |
+
+### localStorage
+
+| Command | Example | Purpose |
+| ------- | ------- | ------- |
+| `localstorage-list` | `cypress-cli localstorage-list` | List all localStorage entries |
+| `localstorage-get` | `cypress-cli localstorage-get token` | Read a localStorage value by key |
+| `localstorage-set` | `cypress-cli localstorage-set token abc123` | Set a localStorage key/value pair |
+| `localstorage-delete` | `cypress-cli localstorage-delete token` | Delete a localStorage key |
+| `localstorage-clear` | `cypress-cli localstorage-clear` | Clear all localStorage entries |
+
+### sessionStorage
+
+| Command | Example | Purpose |
+| ------- | ------- | ------- |
+| `sessionstorage-list` | `cypress-cli sessionstorage-list` | List all sessionStorage entries |
+| `sessionstorage-get` | `cypress-cli sessionstorage-get draft` | Read a sessionStorage value by key |
+| `sessionstorage-set` | `cypress-cli sessionstorage-set draft hello` | Set a sessionStorage key/value pair |
+| `sessionstorage-delete` | `cypress-cli sessionstorage-delete draft` | Delete a sessionStorage key |
+| `sessionstorage-clear` | `cypress-cli sessionstorage-clear` | Clear all sessionStorage entries |
+
+### State
+
+| Command | Example | Purpose |
+| ------- | ------- | ------- |
+| `state-save` | `cypress-cli state-save .cypress-cli/state.json` | Save cookies, localStorage, and sessionStorage to disk |
+| `state-load` | `cypress-cli state-load .cypress-cli/state.json` | Restore cookies, localStorage, and sessionStorage from disk |
+
+### Diagnostics and page capture
+
+| Command | Example | Purpose |
+| ------- | ------- | ------- |
+| `console` | `cypress-cli console` | Return captured browser console messages |
+| `screenshot` | `cypress-cli screenshot` | Capture a page or element screenshot |
+
+## How to read snapshots
+
+The snapshot file (YAML) contains the page's aria tree with element references:
+
+```yaml
+- document [ref=e1]:
+    - heading "Welcome" [level=1] [ref=e2]
+    - textbox "Email" [ref=e3]
+    - button "Submit" [ref=e4]
+```
+
+Use the `ref` values (e.g., `e3`, `e4`) to target elements in subsequent
+commands. Read the snapshot file to see the full page structure.
+
+**Action commands** (click, type, check, etc.) return a **diff** showing only
+what changed. **Snapshot, navigation, and reload** return the **full tree**.
+
+## Workflow
+
+```bash
+# 1. Open a page
+cypress-cli open https://example.com
+
+# 2. Read the snapshot file to see the page structure
+cat .cypress-cli/page-*.yml
+
+# 3. Interact with elements using ref values
+cypress-cli type e3 'user@test.com'
+cypress-cli click e4
+
+# 4. Take a full snapshot anytime
+cypress-cli snapshot
+
+# 5. Assert element state
+cypress-cli assert e3 have.value 'user@test.com'
+
+# 6. Run browser-side JavaScript
+cypress-cli run-code "document.querySelectorAll('input').length"
+
+# 7. Run Cypress chain code in the runner context
+cypress-cli cyrun "cy.url().then(u => u)"
+
+# 8. Use the interactive REPL when you want a prompt
+cypress-cli repl
+# cypress-cli> snapshot
+# cypress-cli> status
+# cypress-cli> exit
+
+# 9. Export session as a Cypress test file
+cypress-cli export --file ./generated.cy.ts
+
+# 10. Run the exported Cypress spec
+cypress-cli run ./generated.cy.ts
+
+# 11. Stop the session
+cypress-cli stop
+```
+
+## Tips
+
+- **Always read the snapshot file** after `open` to discover element refs
+- **Snapshot files accumulate** in `.cypress-cli/` — each command writes a new one
+- Use `--json` flag on any command for machine-readable output
+- `run-code` executes browser-side JavaScript via `window.eval(...)`
+- `eval` returns expression results and can optionally evaluate against a specific ref
+- `cyrun` is for Cypress chain code such as `cy.get(...)`, not browser-side JavaScript
+- `run` executes a Cypress spec file and does not require an active browser session
+- `install --skills` copies this source skill to `.github/skills/cypress-cli/`
+- If a command fails, the response includes an error message and a recovery snapshot
+
+## Waiting after SPA navigation
+
+Single-page apps (SPAs) use client-side routing — clicking a link changes the
+URL and renders new content **without a full page load**. Cypress does not
+automatically wait for SPA route transitions to finish.
+
+After clicking a SPA navigation link, you must explicitly wait before taking a
+snapshot. There are two strategies:
+
+### Strategy 1: Wait for an element (simple)
+
+Use `waitfor` to wait for an element you expect on the new page:
+
+```bash
+cypress-cli click e5                  # Click a SPA nav link
+cypress-cli waitfor e12               # Wait for a known element on the new route
+cypress-cli snapshot                  # Now the snapshot shows the new page
+```
+
+Use this when you know a specific element ref that should appear after the
+navigation. If the new page has not been snapshotted yet, use `asserturl`
+to confirm the route changed, then take a full snapshot:
+
+```bash
+cypress-cli click e5                              # Click SPA nav link
+cypress-cli asserturl include '/dashboard'        # Confirm route changed
+cypress-cli snapshot                              # Full snapshot of new page
+```
+
+### Strategy 2: Wait for a network response (API-driven SPAs)
+
+Many SPAs fetch data from an API when navigating. Use `intercept` +
+`waitforresponse` to wait for that API call to complete:
+
+```bash
+cypress-cli intercept '**/api/articles*'          # Set up intercept BEFORE the click
+cypress-cli click e5                              # Click triggers API call
+cypress-cli waitforresponse '**/api/articles*'    # Wait for API response
+cypress-cli snapshot                              # Page is now fully loaded
+```
+
+This is the idiomatic Cypress pattern: `cy.intercept().as()` + `cy.wait('@alias')`.
+The exported test will contain real Cypress commands.
+
+**Important:** Always register the `intercept` **before** the action that
+triggers the request. Intercepts set up after the request starts will not
+catch it.
+
+## Network mocking
+
+Use `intercept` to mock API responses for testing:
+
+```bash
+# Mock a 200 response with JSON body
+cypress-cli intercept '**/api/users' --status 200 --body '{"users":[]}'
+
+# List active intercepts
+cypress-cli intercept-list
+
+# Remove a specific intercept
+cypress-cli unintercept '**/api/users'
+
+# Remove all intercepts
+cypress-cli unintercept
+
+# View all captured network requests
+cypress-cli network
+```

--- a/.github/skills/cypress-cli/references/network-mocking.md
+++ b/.github/skills/cypress-cli/references/network-mocking.md
@@ -1,0 +1,91 @@
+# Network Mocking & Request Waiting
+
+## Available commands
+
+| Command           | Purpose                                           |
+| ----------------- | ------------------------------------------------- |
+| `intercept`       | Register a URL pattern to intercept/mock requests |
+| `waitforresponse` | Wait for a response matching an intercepted URL   |
+| `unintercept`     | Remove one or all active intercepts               |
+| `intercept-list`  | List all active intercept routes                  |
+| `network`         | List all captured network requests                |
+
+## Mocking API responses
+
+```bash
+# Mock with status code and JSON body
+cypress-cli intercept '**/api/users' --status 200 --body '{"users":[]}'
+
+# Mock with custom content type
+cypress-cli intercept '**/api/health' --body 'OK' --content-type 'text/plain'
+
+# Monitor requests without mocking (no --status or --body)
+cypress-cli intercept '**/api/articles*'
+```
+
+Intercepts map to `cy.intercept()` and are replayed automatically after error
+recovery.
+
+## Waiting for network responses (SPA pattern)
+
+The `intercept` + `waitforresponse` pair is the idiomatic Cypress pattern for
+waiting on API calls. This is essential for SPA navigation where client-side
+route changes trigger API fetches.
+
+```bash
+# 1. Register the intercept BEFORE the action
+cypress-cli intercept '**/api/articles*'
+
+# 2. Perform the action that triggers the API call
+cypress-cli click e5
+
+# 3. Wait for the API response
+cypress-cli waitforresponse '**/api/articles*'
+
+# 4. Now the page is fully loaded
+cypress-cli snapshot
+```
+
+The exported Cypress test will contain:
+
+```js
+cy.intercept('**/api/articles*').as('apiArticles1');
+cy.get('.nav-link').click();
+cy.wait('@apiArticles1');
+```
+
+### Timeout option
+
+```bash
+# Wait up to 15 seconds for a slow API
+cypress-cli waitforresponse '**/api/articles*' --timeout 15000
+```
+
+### Important rules
+
+- **Register intercepts before the triggering action.** An intercept set up
+  after the request fires will not capture it.
+- **The pattern in `waitforresponse` must match a previously registered
+  `intercept`.** If no matching intercept exists, the command will error.
+- Each `intercept` generates a unique alias so that multiple intercepts for
+  different patterns work independently.
+
+## Managing intercepts
+
+```bash
+# List active intercepts
+cypress-cli intercept-list
+
+# Remove a specific intercept
+cypress-cli unintercept '**/api/users'
+
+# Remove all intercepts
+cypress-cli unintercept
+```
+
+## Viewing captured traffic
+
+```bash
+# See all network requests captured since page load
+cypress-cli network
+```

--- a/.github/skills/cypress-cli/references/storage-state.md
+++ b/.github/skills/cypress-cli/references/storage-state.md
@@ -1,0 +1,25 @@
+# Storage state
+
+Storage-state commands are planned but are **not implemented yet** in the
+current `cypress-cli` release.
+
+## Planned scope
+
+The roadmap includes:
+
+- `state-save` / `state-load`
+- cookie commands (`cookie-list`, `cookie-get`, `cookie-set`, `cookie-delete`, `cookie-clear`)
+- localStorage commands
+- sessionStorage commands
+
+These features are expected to use Cypress APIs such as `cy.getCookies()`,
+`cy.setCookie()`, and `cy.window().then(win => win.localStorage.*)`.
+
+## Guidance today
+
+- Do not invoke storage-state commands unless the repository version explicitly
+  documents that they are implemented.
+- If a task needs browser state persistence right now, explain that storage
+  management is planned but not yet available through the CLI.
+- When these commands land, prefer them over ad hoc script injection so the
+  session history and exported tests stay consistent with the CLI model.

--- a/.github/skills/cypress-cli/references/test-generation.md
+++ b/.github/skills/cypress-cli/references/test-generation.md
@@ -1,0 +1,45 @@
+# Test generation
+
+Use `cypress-cli` to build Cypress tests incrementally from real browser
+interactions, then export the session history as a `.cy.ts` or `.cy.js` file.
+
+## How codegen works
+
+1. Start a session with `open`.
+2. Explore the page with `snapshot`.
+3. Interact using commands such as `click`, `type`, `select`, and `assert`.
+4. The daemon records exportable commands in session history.
+5. Run `export` to generate a Cypress test file from the recorded history.
+
+The exported file is generated from recorded command history, not from a guess
+about what happened. If you made a wrong move, use `undo` before exporting.
+
+## Recommended workflow
+
+```bash
+cypress-cli open https://example.cypress.io/commands/actions
+cypress-cli snapshot
+cypress-cli type e40 "qa@example.com"
+cypress-cli click e45
+cypress-cli asserturl include "/commands/actions"
+cypress-cli export --file generated/actions.cy.ts
+```
+
+## Useful commands for codegen
+
+- `history` — inspect the recorded command list
+- `undo` — remove the last recorded step
+- `export --file path` — write the generated test to disk
+- `export --format js|ts` — choose JavaScript or TypeScript output
+- `export --describe name` — override the outer `describe()`
+- `export --it name` — override the test case name
+- `export --baseUrl url` — make generated visits relative to a shared base URL
+
+## Best practices
+
+- Take a fresh `snapshot` before acting on a new page state so refs are current.
+- Prefer semantic flows over brittle one-off interactions.
+- Add assertions while recording so the exported test includes validation.
+- Use `undo` instead of manually editing command history in your head.
+- Review the generated file after export and add any project-specific setup or
+  cleanup that the recording flow does not know about.

--- a/.gitignore
+++ b/.gitignore
@@ -142,3 +142,6 @@ vite.config.js.timestamp-*
 vite.config.ts.timestamp-*
 .playwright-cli/
 *.DS_Store
+
+# Downloaded browser binaries
+chrome-headless-shell/

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -429,16 +429,16 @@ by `tsc` for Node.js.
 
 ### Phase 1–3: Core Implementation ✅ Complete
 
-All planned functionality is implemented and tested (634 unit/integration + 29 E2E = 663 tests):
+All planned functionality is implemented and tested (1009 tests across 52 test files):
 
 - **Aria snapshot port**: Complete port from Playwright (tree generation, YAML rendering,
   incremental diffs, role/accessible name computation).
 - **Daemon**: Socket server, session management, command queue with Promise-based
   blocking, graceful shutdown, idle timeout, session persistence to `$XDG_STATE_HOME`.
-- **CLI client**: Argument parsing (minimist + zod), 43 command schemas, socket
+- **CLI client**: Argument parsing (minimist + zod), 64 command schemas, socket
   connection with retry logic, REPL mode, help text, JSON output.
 - **Cypress layer**: Plugin with getCommand/commandResult task handlers, driver spec
-  with full REPL loop (43 commands), support file for IIFE injection and snapshot
+  with full REPL loop (64 commands), support file for IIFE injection and snapshot
   taking, launcher with cross-process IPC via QueueBridge.
 - **Browser module** (`src/browser/`): Element ref map, selector generation via
   `@cypress/unique-selector` with Cypress priority order, IIFE snapshot injection.
@@ -446,7 +446,7 @@ All planned functionality is implemented and tested (634 unit/integration + 29 E
   describe/it structure, meta-command filtering, TypeScript output.
 - **Integration tests**: Client↔daemon, daemon↔plugin, command queue flow,
   session lifecycle, error propagation (real sockets, mock Cypress).
-- **E2E tests**: 29 tests with real Cypress + Electron against fixture HTML pages.
+- **E2E tests**: Full stack tests with real Cypress + Electron against fixture HTML pages.
 - **Build pipeline**: esbuild IIFE bundling, TypeScript compilation, ESLint with
   TypeScript support.
 
@@ -457,10 +457,11 @@ See `docs/ROADMAP.md` for the full issue list. Key areas:
 - **SKILL file + install command** — primary integration surface for coding agents
 - **Snapshot-to-file output** — token-efficient output model for AI agents
 - **Inline codegen per command** — return generated Cypress code with each response
-- **New commands** — `eval`, `fill`, `drag`, `upload`, `screenshot`, `dialog-accept/dismiss`,
-  `resize`, cookie/storage management, console/network access, network mocking
-- **Command naming alignment** — add `goto` alias, `close` alias
-- **Feasibility audit** — determine which playwright-cli features are achievable in Cypress
+- **New commands** — all P1/P2 commands implemented including `eval`, `fill`, `drag`,
+  `upload`, `screenshot`, `dialog-accept/dismiss`, `resize`, `run`, `cyrun`, `console`,
+  cookie/storage management, network monitoring and mocking
+- **Command naming alignment** — `goto`, `close`, `go-back`, `go-forward` aliases added
+- **Feasibility audit** — complete (see docs/CAPABILITY_MATRIX.md)
 
 ### Future
 

--- a/README.md
+++ b/README.md
@@ -54,13 +54,16 @@ cypress-cli assert e5 contain.text "hello"
 
 # 6. Export your session as a Cypress test
 cypress-cli export --file my-test.cy.ts
+
+# Or start an interactive REPL session (reads commands from stdin line-by-line)
+cypress-cli repl
 ```
 
 ## Commands
 
 | Category    | Commands                                                                   |
 | ----------- | -------------------------------------------------------------------------- |
-| Core        | `open`, `stop`, `status`, `install`, `snapshot`                            |
+| Core        | `open`, `stop`, `status`, `install`, `snapshot`, `repl`                    |
 | Navigation  | `navigate`, `back`, `forward`, `reload`                                    |
 | Interaction | `click`, `dblclick`, `rightclick`, `type`, `clear`, `select`               |
 |             | `check`, `uncheck`, `focus`, `blur`, `scrollto`, `hover`, `fill`           |

--- a/README.md
+++ b/README.md
@@ -56,19 +56,6 @@ cypress-cli assert e5 contain.text "hello"
 cypress-cli export --file my-test.cy.ts
 ```
 
-### Interactive REPL
-
-```bash
-# Start an interactive session
-cypress-cli repl
-
-# Then type commands directly:
-> open https://example.com
-> snapshot
-> click e5
-> export
-```
-
 ## Commands
 
 | Category    | Commands                                                                   |
@@ -76,13 +63,17 @@ cypress-cli repl
 | Core        | `open`, `stop`, `status`, `install`, `snapshot`                            |
 | Navigation  | `navigate`, `back`, `forward`, `reload`                                    |
 | Interaction | `click`, `dblclick`, `rightclick`, `type`, `clear`, `select`               |
-|             | `check`, `uncheck`, `focus`, `blur`, `scrollto`, `hover`                   |
+|             | `check`, `uncheck`, `focus`, `blur`, `scrollto`, `hover`, `fill`           |
 | Keyboard    | `press`                                                                    |
 | Assertion   | `assert`, `asserturl`, `asserttitle`                                       |
-| Execution   | `run-code`                                                                 |
+| Execution   | `run-code`, `eval`, `cyrun`, `run`                                         |
 | Wait        | `wait`, `waitfor`                                                          |
 | Network     | `intercept`, `waitforresponse`, `unintercept`, `intercept-list`, `network` |
-| Storage     | `cookie-list`, `cookie-get`, `cookie-set`, `cookie-delete`, `cookie-clear` |
+| Cookies     | `cookie-list`, `cookie-get`, `cookie-set`, `cookie-delete`, `cookie-clear` |
+| Storage     | `localstorage-list/get/set/delete/clear`                                   |
+|             | `sessionstorage-list/get/set/delete/clear`, `state-save`, `state-load`     |
+| DevTools    | `console`, `screenshot`                                                    |
+| Page        | `drag`, `upload`, `dialog-accept`, `dialog-dismiss`, `resize`              |
 | Export      | `export`, `history`, `undo`                                                |
 
 See [docs/COMMANDS.md](docs/COMMANDS.md) for full syntax, schemas, and Cypress API mappings.

--- a/docs/BLOCKER_FIX_PLAN.md
+++ b/docs/BLOCKER_FIX_PLAN.md
@@ -1,0 +1,509 @@
+# Blocker Fix Plan — 1.0 Pre-Release
+
+> Structured plan for resolving the three blockers and two cleanup items
+> identified during the 1.0 validation runbook (`validation/LLM_VALIDATION_LOG.md`).
+>
+> **Rule:** After completing each numbered step, you MUST:
+>
+> 1. Re-read this plan (`docs/BLOCKER_FIX_PLAN.md`) in full
+> 2. Re-read `validation/LLM_VALIDATION_LOG.md`
+> 3. Append an entry to `validation/LLM_VALIDATION_LOG.md` with your
+>    observations, problems found, and whether the fix resolved the issue
+>
+> Use the same log entry format established by the validation runbook.
+
+---
+
+## Overview
+
+| #   | Task                                     | Severity | Est. Scope           |
+| --- | ---------------------------------------- | -------- | -------------------- |
+| 1   | Fix failed `open` returning stale output | Blocker  | daemon + client code |
+| 2   | Update SKILL.md to match current CLI     | Blocker  | content rewrite      |
+| 3   | Resolve REPL surface ambiguity           | Blocker  | code + docs          |
+| 4   | Re-validate all three fixes live         | Gate     | live CLI testing     |
+| 5   | Clean up stale doc claims                | Cleanup  | docs only            |
+
+---
+
+## Step 1: Fix Failed `open` Returning Stale Output
+
+### Problem
+
+When `open` fails to reach a target URL (network error, unreachable host),
+the CLI still prints `### Page` metadata and a `### Snapshot` path from the
+_previously active session_. This is misleading for LLM workflows because the
+agent believes the new page loaded successfully.
+
+**Validation reference:** Steps 2.5 and 4 in `validation/LLM_VALIDATION_LOG.md`.
+
+### Root Cause Investigation
+
+The `open` command flow is:
+
+1. Client (`src/client/open.ts`) calls `openSession()`, which spawns or
+   reuses a daemon and sends the `open` command
+2. Daemon handler receives `open`, calls `cy.visit(url)` through the driver
+   spec queue
+3. On success, the driver spec takes a snapshot and returns page metadata +
+   snapshot path
+4. On failure, `cy.visit()` throws — but the daemon/client may still return
+   the _previous_ session's page metadata and snapshot rather than a clean
+   error
+
+### What to Fix
+
+Trace the failure path through these files in order:
+
+1. **`src/cypress/driverSpec.ts`** — Find where `cy.visit()` is called for
+   the `open` command. Check what happens when it fails. Does the error
+   propagate, or does the spec fall through to a snapshot of the current
+   (stale) page?
+
+2. **`src/daemon/handlers.ts`** — Find the `open` command handler. Check
+   whether it distinguishes between a successful visit and a failed one.
+   If it always attaches the current page metadata to the response, that's
+   the bug.
+
+3. **`src/daemon/session.ts`** — Check whether the session updates its
+   stored URL/title on `open` before confirming the visit succeeded.
+
+### Expected Fix
+
+When `cy.visit()` fails:
+
+- The response MUST include an error message (e.g., the Cypress error text)
+- The response MUST NOT include page metadata or snapshot paths from a
+  previous session
+- The session's stored URL/title MUST NOT be updated to the failed target
+- The session MUST remain alive (not crash) so the user can retry or issue
+  other commands
+
+### Acceptance Criteria
+
+- [ ] `node bin/cypress-cli open https://httpstat.us/503` (or similar
+      unreachable URL) returns a clear error without any `### Page` or
+      `### Snapshot` section
+- [ ] After the failed open, `node bin/cypress-cli snapshot` still works
+      against the previously opened page (session stays alive)
+- [ ] After the failed open, a subsequent
+      `node bin/cypress-cli open <valid-url>` succeeds normally
+- [ ] Existing `open` tests still pass (`npx vitest run`)
+- [ ] New unit test covers the failed-open-returns-error case
+
+### Log Entry
+
+After completing this step, append a log entry:
+
+```
+### Fix 1 — Failed Open Stale Output — [YYYY-MM-DD HH:MM]
+
+**Status:** Pass / Fail / Partial
+
+**Observations:**
+- [What was the root cause?]
+- [What files were changed?]
+- [Does the fix handle all failure modes: network error, 4xx, 5xx, timeout?]
+
+**Problems Found:**
+- [Any unexpected issues encountered during the fix]
+
+**Verification:**
+- [ ] Error-only output on failed open
+- [ ] Session stays alive after failed open
+- [ ] Subsequent valid open works
+- [ ] npx vitest run passes
+- [ ] npx tsc --noEmit passes
+```
+
+---
+
+## Step 2: Update SKILL.md to Match Current CLI
+
+### Problem
+
+The packaged `skills/cypress-cli/SKILL.md` (installed by `cypress-cli install
+--skills`) is stale:
+
+1. **Wrong output format** — Documents `Snapshot → .cypress-cli/...` but CLI
+   emits `[Snapshot](.cypress-cli/...)` (markdown link under `### Snapshot`)
+2. **Missing commands** — Does not document: `cookie-set`, `cookie-get`,
+   `cookie-delete`, `cookie-list`, `cookie-clear`, `localstorage-set`,
+   `localstorage-get`, `localstorage-list`, `localstorage-delete`,
+   `localstorage-clear`, `sessionstorage-set`, `sessionstorage-get`,
+   `sessionstorage-list`, `sessionstorage-delete`, `sessionstorage-clear`,
+   `state-save`, `state-load`, `console`, `eval`, `cyrun`, `run`
+3. **Wrong example** — Shows `run-code "cy.get('#modal').should('be.visible')"`
+   but `run-code` executes browser-side JavaScript (`window.eval`), not
+   Cypress chain code. That's what `cyrun` does.
+
+**Validation reference:** Step 6 in `validation/LLM_VALIDATION_LOG.md`.
+
+### What to Fix
+
+Edit `skills/cypress-cli/SKILL.md`:
+
+1. **Update the output format section** to show the actual `### Page` /
+   `### Snapshot` format with the markdown link syntax:
+
+   ```
+   ### Page
+   - Page URL: https://example.com
+   - Page Title: Example
+   ### Snapshot
+   [Snapshot](.cypress-cli/page-2026-04-10T19-22-42-679Z.yml)
+   ```
+
+2. **Add all missing commands** to the command table. Group them logically:
+   - **Cookies:** `cookie-set`, `cookie-get`, `cookie-delete`,
+     `cookie-list`, `cookie-clear`
+   - **localStorage:** `localstorage-set`, `localstorage-get`,
+     `localstorage-list`, `localstorage-delete`, `localstorage-clear`
+   - **sessionStorage:** `sessionstorage-set`, `sessionstorage-get`,
+     `sessionstorage-list`, `sessionstorage-delete`, `sessionstorage-clear`
+   - **State:** `state-save`, `state-load`
+   - **DevTools:** `console`
+   - **Execution:** `eval`, `cyrun`, `run`
+
+3. **Fix the `run-code` example** — Replace the Cypress-chain example with
+   a browser-side JavaScript example:
+
+   ```
+   cypress-cli run-code "document.querySelectorAll('input').length"
+   ```
+
+   Add a separate `cyrun` example for Cypress chain execution:
+
+   ```
+   cypress-cli cyrun "cy.url().then(u => u)"
+   ```
+
+4. **Remove any REPL references** if present (see Step 3 decision below).
+
+5. **Cross-check against `docs/COMMANDS.md`** — The skill does not need to
+   document every command in detail, but its command table should cover all
+   64 commands and the descriptions should match what the commands actually
+   do.
+
+### Source of Truth
+
+Use these files as the authoritative reference for what each command does:
+
+- `docs/COMMANDS.md` — Full command schemas and Cypress API mappings
+- `src/client/commands.ts` — Command definitions with descriptions
+- `validation/LLM_VALIDATION_LOG.md` — Observed real behavior during validation
+
+### Acceptance Criteria
+
+- [ ] Output format example matches actual CLI output
+- [ ] All 64 commands are represented in the skill (at least by category
+      if not individually)
+- [ ] `run-code` example uses browser-side JS, not Cypress chain code
+- [ ] `cyrun` is documented with a Cypress chain example
+- [ ] No references to REPL (unless Step 3 decides to expose it)
+- [ ] `node bin/cypress-cli install --skills` installs the updated file
+- [ ] The installed SKILL.md matches the source in `skills/cypress-cli/`
+
+### Log Entry
+
+After completing this step, append a log entry:
+
+```
+### Fix 2 — SKILL.md Update — [YYYY-MM-DD HH:MM]
+
+**Status:** Pass / Fail / Partial
+
+**Observations:**
+- [What sections were updated?]
+- [How many commands were added?]
+- [Were any other inaccuracies found during the update?]
+
+**Problems Found:**
+- [Any issues with install --skills or file placement]
+
+**Verification:**
+- [ ] Output format matches CLI
+- [ ] All 64 commands represented
+- [ ] run-code example is browser-side JS
+- [ ] cyrun documented with Cypress chain example
+- [ ] install --skills works correctly
+```
+
+---
+
+## Step 3: Resolve REPL Surface Ambiguity
+
+### Problem
+
+`src/client/repl.ts` contains a fully implemented `startRepl()` function,
+but it is not registered in `src/client/commands.ts` or dispatched in
+`src/client/cli.ts`. Running `node bin/cypress-cli repl` returns
+`Error: Unknown command "repl"`.
+
+Meanwhile, these docs still reference REPL as part of the product surface:
+
+- `docs/READINESS_ASSESSMENT.md` — Claims REPL mode is "complete"
+- `docs/LLM_VALIDATION_RUNBOOK.md` — Step 3.11 expects to test it
+
+The README was already fixed inline during validation (REPL section removed).
+
+**Validation reference:** Step 3.11 in `validation/LLM_VALIDATION_LOG.md`.
+
+### Decision: Expose REPL as a public command
+
+The REPL implementation in `src/client/repl.ts` is fully functional — it
+has a readline loop, command parsing with quoting support, session reuse,
+and clean exit handling. It was built as part of the original CLI client
+PR but was never wired into the dispatch path. The code has been maintained
+across subsequent PRs (including `fix: route local commands in repl`).
+
+The fix is small: register the command and add a dispatch case.
+
+### What to Fix
+
+1. **`src/client/commands.ts`** — Register `repl` as a command:
+   - Category: `core`
+   - Description: something like `Start interactive REPL mode`
+   - Schema: no required args (session and json are global flags)
+   - This will increment `allCommands.length` and `commandRegistry.size`
+     — update the count expectations in
+     `tests/unit/client/commands.test.ts` accordingly
+
+2. **`src/client/cli.ts`** — Add dispatch before the daemon send path:
+
+   ```typescript
+   if (parsedCommand.command === 'repl') {
+   	await startRepl({ session: flags.session, json: flags.json });
+   	return { exitCode: EXIT_SUCCESS, output: '' };
+   }
+   ```
+
+   Import `startRepl` from `./repl.js`.
+
+3. **`skills/cypress-cli/SKILL.md`** — Document REPL usage in the command
+   table and add a brief workflow example (handled in Step 2).
+
+4. **Tests** — The command registration test in
+   `tests/unit/client/commands.test.ts` checks `allCommands.length` and
+   `commandRegistry.size`. Update both counts (+1 each). Add a test that
+   `repl` is in the registry.
+
+### Acceptance Criteria
+
+- [ ] `node bin/cypress-cli repl` enters interactive mode with a
+      `cypress-cli> ` prompt
+- [ ] Commands typed in REPL (e.g. `snapshot`, `status`) execute and
+      return output
+- [ ] `exit` or Ctrl+D exits cleanly
+- [ ] `node bin/cypress-cli --help` lists `repl` under core commands
+- [ ] Unit test for REPL command registration exists
+- [ ] `allCommands.length` and `commandRegistry.size` test expectations
+      updated
+- [ ] SKILL.md documents REPL usage (done in Step 2)
+
+### Log Entry
+
+After completing this step, append a log entry:
+
+```
+### Fix 3 — REPL Wired Up — [YYYY-MM-DD HH:MM]
+
+**Status:** Pass / Fail / Partial
+
+**Observations:**
+- [What files were changed]
+- [Does it work interactively?]
+- [What are the new command/registry counts?]
+
+**Problems Found:**
+- [Any unexpected issues]
+
+**Verification:**
+- [ ] `node bin/cypress-cli repl` enters interactive mode
+- [ ] Commands execute in REPL
+- [ ] exit/Ctrl+D works
+- [ ] --help lists repl
+- [ ] Command count tests updated and passing
+- [ ] npx vitest run passes
+- [ ] npx tsc --noEmit passes
+```
+
+---
+
+## Step 4: Re-Validate All Three Fixes Live
+
+### Purpose
+
+Steps 1–3 are code/doc changes. This step confirms they actually work
+against a live browser, not just in tests. **Do not skip this.**
+
+### Procedure
+
+```bash
+# 1. Build
+npm run build
+
+# 2. Run full check suite
+npx tsc --noEmit
+npx vitest run
+npx eslint src/ tests/
+
+# 3. Validate Fix 1: Failed open returns clean error
+node bin/cypress-cli open https://example.cypress.io/commands/actions
+# Should succeed normally
+
+node bin/cypress-cli open https://httpstat.us/503
+# Should return error WITHOUT ### Page or ### Snapshot from previous session
+
+node bin/cypress-cli snapshot
+# Should still work (session alive from the first successful open)
+
+node bin/cypress-cli open https://example.cypress.io/commands/actions
+# Should succeed (recovery after failed open)
+
+# 4. Validate Fix 2: SKILL.md is accurate
+node bin/cypress-cli install --skills
+cat .github/skills/cypress-cli/SKILL.md
+# Visually confirm: output format matches, all commands present,
+# run-code example is browser JS, cyrun example is Cypress chain
+
+# 5. Validate Fix 3: REPL works
+node bin/cypress-cli repl
+#    Type: snapshot
+#    Type: exit
+#    Should work interactively and exit cleanly
+
+# 6. Clean up
+node bin/cypress-cli stop
+```
+
+### Acceptance Criteria
+
+- [ ] `npm run build` succeeds
+- [ ] `npx tsc --noEmit` passes
+- [ ] `npx vitest run` — all tests pass, no regressions
+- [ ] `npx eslint src/ tests/` — 0 errors, 0 warnings
+- [ ] Fix 1 verified live: clean error on failed open, session survives
+- [ ] Fix 2 verified live: installed SKILL.md matches current CLI
+- [ ] Fix 3 verified live: REPL behavior matches chosen option
+
+### Log Entry
+
+After completing this step, append a log entry:
+
+```
+### Fix 4 — Re-Validation — [YYYY-MM-DD HH:MM]
+
+**Status:** Pass / Fail / Partial
+
+**Baseline:**
+- Build: [pass/fail]
+- Typecheck: [pass/fail]
+- Tests: [count] passing, [count] failing
+- Lint: [errors] errors, [warnings] warnings
+
+**Fix 1 Re-Validation:**
+- Failed open output: [clean error / still stale — describe]
+- Session alive after failed open: [yes/no]
+- Recovery open: [success/fail]
+
+**Fix 2 Re-Validation:**
+- install --skills: [success/fail]
+- Output format correct: [yes/no]
+- Command coverage complete: [yes/no]
+- Examples accurate: [yes/no]
+
+**Fix 3 Re-Validation:**
+- REPL behavior: [matches chosen option / unexpected behavior — describe]
+
+**Problems Found:**
+- [Any issues found during re-validation]
+
+**Verdict:**
+- [ ] All three fixes confirmed working live
+- [ ] Ready to proceed to Step 5 (doc cleanup)
+```
+
+---
+
+## Step 5: Clean Up Stale Doc Claims
+
+### Problem
+
+`docs/READINESS_ASSESSMENT.md` claims certain issues are resolved when
+validation proved they are not. This creates confusion for anyone reading
+the docs to assess release readiness.
+
+### What to Fix
+
+1. **`docs/READINESS_ASSESSMENT.md`** — Find the "Nice-to-have (Resolved)"
+   section that claims `tsconfig-paths` warnings were addressed. Update it
+   to reflect reality:
+   - The warnings still appear during `npx vitest run`
+   - They are non-fatal and do not affect test results
+   - Classify as "known noise, not blocking 1.0"
+
+2. **`docs/READINESS_ASSESSMENT.md`** — Find ANY claims about
+   `MaxListenersExceededWarning` being resolved. Update similarly:
+   - The warning still appears during e2e navigation tests
+   - It is non-fatal
+   - Classify as "known noise, not blocking 1.0"
+
+3. **`docs/READINESS_ASSESSMENT.md`** — Update the REPL status to match
+   the decision from Step 3.
+
+4. **`docs/LLM_VALIDATION_RUNBOOK.md`** — If Step 3 chose Option B (REPL
+   removed from 1.0), update or annotate Step 3.11 to note that REPL
+   validation is deferred.
+
+5. **General sweep** — Search for any other stale claims across `docs/`
+   and `validation/` that were flagged in the validation log. The log
+   entries marked `→ Action: deferred` are the candidates. For each one,
+   either fix the doc or add a note acknowledging the known limitation.
+
+### Acceptance Criteria
+
+- [ ] No doc claims `tsconfig-paths` warnings are resolved
+- [ ] No doc claims `MaxListenersExceededWarning` is resolved
+- [ ] REPL status in docs matches Step 3 decision
+- [ ] Runbook Step 3.11 updated if REPL was deferred
+- [ ] No other stale claims remain in docs that contradict validation findings
+
+### Log Entry
+
+After completing this step, append a log entry:
+
+```
+### Fix 5 — Doc Cleanup — [YYYY-MM-DD HH:MM]
+
+**Status:** Pass / Fail / Partial
+
+**Observations:**
+- [What docs were updated]
+- [How many stale claims were found and fixed]
+
+**Problems Found:**
+- [Any surprises]
+
+**Final Verdict:**
+- [ ] All 5 steps complete
+- [ ] All check commands pass (build, typecheck, test, lint)
+- [ ] All 3 blockers resolved and verified live
+- [ ] Docs are consistent with actual product behavior
+- [ ] Ready for 1.0 tag and release
+```
+
+---
+
+## After All Steps
+
+Once all five steps are complete and all log entries are appended, update
+`validation/LLM_VALIDATION_RESULTS.md`:
+
+1. Change the verdict from **NOT READY** to **READY** (or document why
+   it's still not ready)
+2. Move the three resolved blockers to a "Resolved" section
+3. Update the summary table with final step counts
+4. Add a final timestamp
+
+Then proceed to the release steps in `docs/LAUNCH_PLAN.md` Phase 2.

--- a/docs/CAPABILITY_MATRIX.md
+++ b/docs/CAPABILITY_MATRIX.md
@@ -18,35 +18,35 @@
 
 ### Core
 
-| playwright-cli command     | Classification | cypress-cli | Cypress API / Approach                    | Notes                                                                         |
-| -------------------------- | -------------- | ----------- | ----------------------------------------- | ----------------------------------------------------------------------------- |
-| `open [url]`               | Direct         | `open`      | `cypress.run()` + `cy.visit(url)`         | Implemented                                                                   |
-| `goto <url>`               | Direct         | `navigate`  | `cy.visit(url)`                           | Implemented (alias `goto` planned in #55)                                     |
-| `close`                    | Direct         | `stop`      | Terminate Cypress process                 | Implemented (alias `close` planned in #55)                                    |
-| `type <text>`              | Direct         | `type`      | `cy.get(sel).type(text)`                  | Implemented                                                                   |
-| `click <ref>`              | Direct         | `click`     | `cy.get(sel).click()`                     | Implemented                                                                   |
-| `dblclick <ref>`           | Direct         | `dblclick`  | `cy.get(sel).dblclick()`                  | Implemented                                                                   |
-| `fill <ref> <text>`        | Direct         | —           | `cy.get(sel).clear().type(text)`          | Planned in #49                                                                |
-| `drag <startRef> <endRef>` | Limited        | —           | `cy.trigger()` chain or plugin            | Planned in #53; synthetic events — may not work with all drag-and-drop libs   |
-| `hover <ref>`              | Limited        | `hover`     | `cy.get(sel).trigger('mouseover')`        | Implemented; synthetic event, not native hover — CSS `:hover` may not trigger |
-| `select <ref> <val>`       | Direct         | `select`    | `cy.get(sel).select(value)`               | Implemented                                                                   |
-| `upload <file>`            | Direct         | —           | `cy.get(sel).selectFile(path)`            | Planned in #54; `selectFile()` available since Cypress 9.3                    |
-| `check <ref>`              | Direct         | `check`     | `cy.get(sel).check()`                     | Implemented                                                                   |
-| `uncheck <ref>`            | Direct         | `uncheck`   | `cy.get(sel).uncheck()`                   | Implemented                                                                   |
-| `snapshot`                 | Direct         | `snapshot`  | Injected aria snapshot IIFE               | Implemented                                                                   |
-| `snapshot --filename=f`    | Direct         | `snapshot`  | Same, with file output                    | Planned in #45 (snapshot-to-file)                                             |
-| `eval <func> [ref]`        | Workaround     | —           | `cy.window().then(win => win.eval(func))` | Planned in #48; page-level eval is straightforward, element eval needs ref    |
-| `dialog-accept [prompt]`   | Workaround     | —           | `cy.on('window:confirm', () => true)`     | Planned in #50; must register listener _before_ trigger action                |
-| `dialog-dismiss`           | Workaround     | —           | `cy.on('window:confirm', () => false)`    | Planned in #50; same pre-registration requirement                             |
-| `resize <w> <h>`           | Direct         | —           | `cy.viewport(w, h)`                       | Planned in #51                                                                |
+| playwright-cli command     | Classification | cypress-cli      | Cypress API / Approach                    | Notes                                                                         |
+| -------------------------- | -------------- | ---------------- | ----------------------------------------- | ----------------------------------------------------------------------------- |
+| `open [url]`               | Direct         | `open`           | `cypress.run()` + `cy.visit(url)`         | Implemented                                                                   |
+| `goto <url>`               | Direct         | `navigate`       | `cy.visit(url)`                           | Implemented (alias `goto` added in #55)                                       |
+| `close`                    | Direct         | `stop`           | Terminate Cypress process                 | Implemented (alias `close` added in #55)                                      |
+| `type <text>`              | Direct         | `type`           | `cy.get(sel).type(text)`                  | Implemented                                                                   |
+| `click <ref>`              | Direct         | `click`          | `cy.get(sel).click()`                     | Implemented                                                                   |
+| `dblclick <ref>`           | Direct         | `dblclick`       | `cy.get(sel).dblclick()`                  | Implemented                                                                   |
+| `fill <ref> <text>`        | Direct         | `fill`           | `cy.get(sel).clear().type(text)`          | ✅ Implemented                                                                |
+| `drag <startRef> <endRef>` | Limited        | `drag`           | `cy.trigger()` chain or plugin            | ✅ Implemented; synthetic events — may not work with all drag-and-drop libs   |
+| `hover <ref>`              | Limited        | `hover`          | `cy.get(sel).trigger('mouseover')`        | Implemented; synthetic event, not native hover — CSS `:hover` may not trigger |
+| `select <ref> <val>`       | Direct         | `select`         | `cy.get(sel).select(value)`               | Implemented                                                                   |
+| `upload <file>`            | Direct         | `upload`         | `cy.get(sel).selectFile(path)`            | ✅ Implemented; `selectFile()` available since Cypress 9.3                    |
+| `check <ref>`              | Direct         | `check`          | `cy.get(sel).check()`                     | Implemented                                                                   |
+| `uncheck <ref>`            | Direct         | `uncheck`        | `cy.get(sel).uncheck()`                   | Implemented                                                                   |
+| `snapshot`                 | Direct         | `snapshot`       | Injected aria snapshot IIFE               | Implemented                                                                   |
+| `snapshot --filename=f`    | Direct         | `snapshot`       | Same, with file output                    | ✅ Implemented (snapshot-to-file)                                             |
+| `eval <func> [ref]`        | Workaround     | `eval`           | `cy.window().then(win => win.eval(func))` | ✅ Implemented; page-level eval is straightforward, element eval needs ref    |
+| `dialog-accept [prompt]`   | Workaround     | `dialog-accept`  | `cy.on('window:confirm', () => true)`     | ✅ Implemented; must register listener _before_ trigger action                |
+| `dialog-dismiss`           | Workaround     | `dialog-dismiss` | `cy.on('window:confirm', () => false)`    | ✅ Implemented; same pre-registration requirement                             |
+| `resize <w> <h>`           | Direct         | `resize`         | `cy.viewport(w, h)`                       | ✅ Implemented                                                                |
 
 ### Navigation
 
-| playwright-cli command | Classification | cypress-cli | Cypress API / Approach | Notes                              |
-| ---------------------- | -------------- | ----------- | ---------------------- | ---------------------------------- |
-| `go-back`              | Direct         | `back`      | `cy.go('back')`        | Implemented (alias planned in #55) |
-| `go-forward`           | Direct         | `forward`   | `cy.go('forward')`     | Implemented (alias planned in #55) |
-| `reload`               | Direct         | `reload`    | `cy.reload()`          | Implemented                        |
+| playwright-cli command | Classification | cypress-cli | Cypress API / Approach | Notes                                         |
+| ---------------------- | -------------- | ----------- | ---------------------- | --------------------------------------------- |
+| `go-back`              | Direct         | `back`      | `cy.go('back')`        | Implemented (alias `go-back` added in #55)    |
+| `go-forward`           | Direct         | `forward`   | `cy.go('forward')`     | Implemented (alias `go-forward` added in #55) |
+| `reload`               | Direct         | `reload`    | `cy.reload()`          | Implemented                                   |
 
 ### Keyboard
 
@@ -67,12 +67,12 @@
 
 ### Save As
 
-| playwright-cli command    | Classification | cypress-cli | Cypress API / Approach                         | Notes                                                                 |
-| ------------------------- | -------------- | ----------- | ---------------------------------------------- | --------------------------------------------------------------------- |
-| `screenshot [ref]`        | Direct         | —           | `cy.screenshot()` / `cy.get(sel).screenshot()` | Planned in #52; Cypress supports both page and element screenshots    |
-| `screenshot --filename=f` | Direct         | —           | `cy.screenshot(filename)`                      | Planned in #52                                                        |
-| `pdf`                     | Infeasible     | —           | —                                              | Cypress has no PDF generation API; would require CDP or external tool |
-| `pdf --filename=page.pdf` | Infeasible     | —           | —                                              | Same — no Cypress PDF support                                         |
+| playwright-cli command    | Classification | cypress-cli  | Cypress API / Approach                         | Notes                                                                 |
+| ------------------------- | -------------- | ------------ | ---------------------------------------------- | --------------------------------------------------------------------- |
+| `screenshot [ref]`        | Direct         | `screenshot` | `cy.screenshot()` / `cy.get(sel).screenshot()` | ✅ Implemented; Cypress supports both page and element screenshots    |
+| `screenshot --filename=f` | Direct         | `screenshot` | `cy.screenshot(filename)`                      | ✅ Implemented                                                        |
+| `pdf`                     | Infeasible     | —            | —                                              | Cypress has no PDF generation API; would require CDP or external tool |
+| `pdf --filename=page.pdf` | Infeasible     | —            | —                                              | Same — no Cypress PDF support                                         |
 
 ### Tabs
 
@@ -85,25 +85,25 @@
 
 ### Storage
 
-| playwright-cli command       | Classification | cypress-cli | Cypress API / Approach                                                 | Notes                                                 |
-| ---------------------------- | -------------- | ----------- | ---------------------------------------------------------------------- | ----------------------------------------------------- |
-| `state-save [filename]`      | Workaround     | —           | Serialize cookies + localStorage via `cy.getCookies()` + `cy.window()` | Planned in #60; manual serialization to JSON file     |
-| `state-load <filename>`      | Workaround     | —           | Restore via `cy.setCookie()` + `cy.window().then()`                    | Planned in #60; manual deserialization from JSON file |
-| `cookie-list [--domain]`     | Direct         | —           | `cy.getCookies()`                                                      | Planned in #56                                        |
-| `cookie-get <name>`          | Direct         | —           | `cy.getCookie(name)`                                                   | Planned in #56                                        |
-| `cookie-set <name> <val>`    | Direct         | —           | `cy.setCookie(name, value)`                                            | Planned in #56                                        |
-| `cookie-delete <name>`       | Direct         | —           | `cy.clearCookie(name)`                                                 | Planned in #56                                        |
-| `cookie-clear`               | Direct         | —           | `cy.clearCookies()`                                                    | Planned in #56                                        |
-| `localstorage-list`          | Workaround     | —           | `cy.window().then(win => Object.entries(win.localStorage))`            | Planned in #57                                        |
-| `localstorage-get <key>`     | Workaround     | —           | `cy.window().then(win => win.localStorage.getItem(key))`               | Planned in #57                                        |
-| `localstorage-set <k> <v>`   | Workaround     | —           | `cy.window().then(win => win.localStorage.setItem(k, v))`              | Planned in #57                                        |
-| `localstorage-delete <k>`    | Workaround     | —           | `cy.window().then(win => win.localStorage.removeItem(k))`              | Planned in #57                                        |
-| `localstorage-clear`         | Workaround     | —           | `cy.window().then(win => win.localStorage.clear())`                    | Planned in #57                                        |
-| `sessionstorage-list`        | Workaround     | —           | `cy.window().then(win => Object.entries(win.sessionStorage))`          | Planned in #57                                        |
-| `sessionstorage-get <k>`     | Workaround     | —           | `cy.window().then(win => win.sessionStorage.getItem(k))`               | Planned in #57                                        |
-| `sessionstorage-set <k> <v>` | Workaround     | —           | `cy.window().then(win => win.sessionStorage.setItem(k, v))`            | Planned in #57                                        |
-| `sessionstorage-delete <k>`  | Workaround     | —           | `cy.window().then(win => win.sessionStorage.removeItem(k))`            | Planned in #57                                        |
-| `sessionstorage-clear`       | Workaround     | —           | `cy.window().then(win => win.sessionStorage.clear())`                  | Planned in #57                                        |
+| playwright-cli command       | Classification | cypress-cli             | Cypress API / Approach                                                 | Notes          |
+| ---------------------------- | -------------- | ----------------------- | ---------------------------------------------------------------------- | -------------- |
+| `state-save [filename]`      | Workaround     | `state-save`            | Serialize cookies + localStorage via `cy.getCookies()` + `cy.window()` | ✅ Implemented |
+| `state-load <filename>`      | Workaround     | `state-load`            | Restore via `cy.setCookie()` + `cy.window().then()`                    | ✅ Implemented |
+| `cookie-list [--domain]`     | Direct         | `cookie-list`           | `cy.getCookies()`                                                      | ✅ Implemented |
+| `cookie-get <name>`          | Direct         | `cookie-get`            | `cy.getCookie(name)`                                                   | ✅ Implemented |
+| `cookie-set <name> <val>`    | Direct         | `cookie-set`            | `cy.setCookie(name, value)`                                            | ✅ Implemented |
+| `cookie-delete <name>`       | Direct         | `cookie-delete`         | `cy.clearCookie(name)`                                                 | ✅ Implemented |
+| `cookie-clear`               | Direct         | `cookie-clear`          | `cy.clearCookies()`                                                    | ✅ Implemented |
+| `localstorage-list`          | Workaround     | `localstorage-list`     | `cy.window().then(win => Object.entries(win.localStorage))`            | ✅ Implemented |
+| `localstorage-get <key>`     | Workaround     | `localstorage-get`      | `cy.window().then(win => win.localStorage.getItem(key))`               | ✅ Implemented |
+| `localstorage-set <k> <v>`   | Workaround     | `localstorage-set`      | `cy.window().then(win => win.localStorage.setItem(k, v))`              | ✅ Implemented |
+| `localstorage-delete <k>`    | Workaround     | `localstorage-delete`   | `cy.window().then(win => win.localStorage.removeItem(k))`              | ✅ Implemented |
+| `localstorage-clear`         | Workaround     | `localstorage-clear`    | `cy.window().then(win => win.localStorage.clear())`                    | ✅ Implemented |
+| `sessionstorage-list`        | Workaround     | `sessionstorage-list`   | `cy.window().then(win => Object.entries(win.sessionStorage))`          | ✅ Implemented |
+| `sessionstorage-get <k>`     | Workaround     | `sessionstorage-get`    | `cy.window().then(win => win.sessionStorage.getItem(k))`               | ✅ Implemented |
+| `sessionstorage-set <k> <v>` | Workaround     | `sessionstorage-set`    | `cy.window().then(win => win.sessionStorage.setItem(k, v))`            | ✅ Implemented |
+| `sessionstorage-delete <k>`  | Workaround     | `sessionstorage-delete` | `cy.window().then(win => win.sessionStorage.removeItem(k))`            | ✅ Implemented |
+| `sessionstorage-clear`       | Workaround     | `sessionstorage-clear`  | `cy.window().then(win => win.sessionStorage.clear())`                  | ✅ Implemented |
 
 ### Network
 
@@ -117,14 +117,14 @@
 
 ### DevTools
 
-| playwright-cli command  | Classification | cypress-cli | Cypress API / Approach                                           | Notes                                                                                         |
-| ----------------------- | -------------- | ----------- | ---------------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
-| `console [min-level]`   | Workaround     | —           | `Cypress.on('window:before:load', win => win.console.log = spy)` | Planned in #58; requires monkey-patching console before page load                             |
-| `run-code <code>`       | Workaround     | —           | `cy.window().then(win => win.eval(code))`                        | Planned in #61; equivalent to eval but runs arbitrary Playwright code → needs Cypress mapping |
-| `tracing-start`         | Infeasible     | —           | —                                                                | Cypress only supports config-level `video: true`; no runtime start/stop                       |
-| `tracing-stop`          | Infeasible     | —           | —                                                                | Same — tracing is a launch-time config, not a runtime toggle                                  |
-| `video-start`           | Infeasible     | —           | —                                                                | Cypress `video: true` is config-only; cannot start mid-session                                |
-| `video-stop [filename]` | Infeasible     | —           | —                                                                | Cannot stop/save video mid-session; file is written at Cypress process exit                   |
+| playwright-cli command  | Classification | cypress-cli | Cypress API / Approach                                           | Notes                                                                       |
+| ----------------------- | -------------- | ----------- | ---------------------------------------------------------------- | --------------------------------------------------------------------------- |
+| `console [min-level]`   | Workaround     | `console`   | `Cypress.on('window:before:load', win => win.console.log = spy)` | ✅ Implemented; monkey-patches console before page load                     |
+| `run-code <code>`       | Workaround     | `run-code`  | `cy.window().then(win => win.eval(code))`                        | ✅ Implemented (PR #93)                                                     |
+| `tracing-start`         | Infeasible     | —           | —                                                                | Cypress only supports config-level `video: true`; no runtime start/stop     |
+| `tracing-stop`          | Infeasible     | —           | —                                                                | Same — tracing is a launch-time config, not a runtime toggle                |
+| `video-start`           | Infeasible     | —           | —                                                                | Cypress `video: true` is config-only; cannot start mid-session              |
+| `video-stop [filename]` | Infeasible     | —           | —                                                                | Cannot stop/save video mid-session; file is written at Cypress process exit |
 
 ### Session Management
 

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -104,11 +104,11 @@ inside the REPL is then parsed and sent through the normal client/daemon flow.
 
 ### Execution
 
-| Command    | Syntax                                                     | Description                                                       |
-| ---------- | ---------------------------------------------------------- | ----------------------------------------------------------------- |
-| `run-code` | `cypress-cli run-code <code>`                              | Execute JS in browser (`cy.window().then(win => win.eval(code))`) |
-| `eval`     | `cypress-cli eval <expression> [ref]`                      | Evaluate JS expression on page or on a specific element           |
-| `cyrun`    | `cypress-cli cyrun <code>`                                 | Execute arbitrary Cypress chain string in the runner context       |
+| Command    | Syntax                                                           | Description                                                       |
+| ---------- | ---------------------------------------------------------------- | ----------------------------------------------------------------- |
+| `run-code` | `cypress-cli run-code <code>`                                    | Execute JS in browser (`cy.window().then(win => win.eval(code))`) |
+| `eval`     | `cypress-cli eval <expression> [ref]`                            | Evaluate JS expression on page or on a specific element           |
+| `cyrun`    | `cypress-cli cyrun <code>`                                       | Execute arbitrary Cypress chain string in the runner context      |
 | `run`      | `cypress-cli run <file> [--browser chrome\|electron] [--headed]` | Run a Cypress test file and report structured results             |
 
 ### Wait
@@ -130,25 +130,25 @@ inside the REPL is then parsed and sent through the normal client/daemon flow.
 
 ### Storage
 
-| Command                 | Syntax                                                                                           | Description                                                    |
-| ----------------------- | ------------------------------------------------------------------------------------------------ | -------------------------------------------------------------- |
-| `cookie-list`           | `cypress-cli cookie-list [--domain domain]`                                                      | List cookies, optionally filtered by domain                    |
-| `cookie-get`            | `cypress-cli cookie-get <name>`                                                                  | Get a cookie by name (`cy.getCookie()`)                        |
-| `cookie-set`            | `cypress-cli cookie-set <name> <value> [--domain d] [--httpOnly] [--secure] [--path p]`         | Set a cookie (`cy.setCookie()`)                                |
-| `cookie-delete`         | `cypress-cli cookie-delete <name>`                                                               | Delete a cookie by name (`cy.clearCookie()`)                   |
-| `cookie-clear`          | `cypress-cli cookie-clear`                                                                       | Clear all cookies (`cy.clearCookies()`)                        |
-| `state-save`            | `cypress-cli state-save [filename]`                                                              | Save cookies, localStorage, and sessionStorage to JSON         |
-| `state-load`            | `cypress-cli state-load <filename>`                                                              | Load cookies, localStorage, and sessionStorage from JSON       |
-| `localstorage-list`     | `cypress-cli localstorage-list`                                                                  | List all localStorage entries as JSON                          |
-| `localstorage-get`      | `cypress-cli localstorage-get <key>`                                                             | Get a localStorage value by key                                |
-| `localstorage-set`      | `cypress-cli localstorage-set <key> <value>`                                                     | Set a localStorage key-value pair                              |
-| `localstorage-delete`   | `cypress-cli localstorage-delete <key>`                                                          | Delete a localStorage entry by key                             |
-| `localstorage-clear`    | `cypress-cli localstorage-clear`                                                                 | Clear all localStorage entries (`cy.clearLocalStorage()`)      |
-| `sessionstorage-list`   | `cypress-cli sessionstorage-list`                                                                | List all sessionStorage entries as JSON                        |
-| `sessionstorage-get`    | `cypress-cli sessionstorage-get <key>`                                                           | Get a sessionStorage value by key                              |
-| `sessionstorage-set`    | `cypress-cli sessionstorage-set <key> <value>`                                                   | Set a sessionStorage key-value pair                            |
-| `sessionstorage-delete` | `cypress-cli sessionstorage-delete <key>`                                                        | Delete a sessionStorage entry by key                           |
-| `sessionstorage-clear`  | `cypress-cli sessionstorage-clear`                                                               | Clear all sessionStorage entries                               |
+| Command                 | Syntax                                                                                  | Description                                               |
+| ----------------------- | --------------------------------------------------------------------------------------- | --------------------------------------------------------- |
+| `cookie-list`           | `cypress-cli cookie-list [--domain domain]`                                             | List cookies, optionally filtered by domain               |
+| `cookie-get`            | `cypress-cli cookie-get <name>`                                                         | Get a cookie by name (`cy.getCookie()`)                   |
+| `cookie-set`            | `cypress-cli cookie-set <name> <value> [--domain d] [--httpOnly] [--secure] [--path p]` | Set a cookie (`cy.setCookie()`)                           |
+| `cookie-delete`         | `cypress-cli cookie-delete <name>`                                                      | Delete a cookie by name (`cy.clearCookie()`)              |
+| `cookie-clear`          | `cypress-cli cookie-clear`                                                              | Clear all cookies (`cy.clearCookies()`)                   |
+| `state-save`            | `cypress-cli state-save [filename]`                                                     | Save cookies, localStorage, and sessionStorage to JSON    |
+| `state-load`            | `cypress-cli state-load <filename>`                                                     | Load cookies, localStorage, and sessionStorage from JSON  |
+| `localstorage-list`     | `cypress-cli localstorage-list`                                                         | List all localStorage entries as JSON                     |
+| `localstorage-get`      | `cypress-cli localstorage-get <key>`                                                    | Get a localStorage value by key                           |
+| `localstorage-set`      | `cypress-cli localstorage-set <key> <value>`                                            | Set a localStorage key-value pair                         |
+| `localstorage-delete`   | `cypress-cli localstorage-delete <key>`                                                 | Delete a localStorage entry by key                        |
+| `localstorage-clear`    | `cypress-cli localstorage-clear`                                                        | Clear all localStorage entries (`cy.clearLocalStorage()`) |
+| `sessionstorage-list`   | `cypress-cli sessionstorage-list`                                                       | List all sessionStorage entries as JSON                   |
+| `sessionstorage-get`    | `cypress-cli sessionstorage-get <key>`                                                  | Get a sessionStorage value by key                         |
+| `sessionstorage-set`    | `cypress-cli sessionstorage-set <key> <value>`                                          | Set a sessionStorage key-value pair                       |
+| `sessionstorage-delete` | `cypress-cli sessionstorage-delete <key>`                                               | Delete a sessionStorage entry by key                      |
+| `sessionstorage-clear`  | `cypress-cli sessionstorage-clear`                                                      | Clear all sessionStorage entries                          |
 
 ## Command Schemas (zod)
 

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -28,20 +28,25 @@ The `method` is always `"run"` for command execution or `"stop"` for shutdown.
 The `args._` array contains the command name followed by positional arguments,
 matching minimist's parsing convention.
 
-`install --skills` is a client-local command. It does not connect to the daemon
-or require a running Cypress session.
+`install --skills` and `repl` are client-local commands. `install --skills`
+copies the bundled skill into the current project without starting or using a
+browser session. `repl` starts an interactive local prompt; each command typed
+inside the REPL is then parsed and sent through the normal client/daemon flow.
 
 ## Command Categories
 
 ### Core
 
-| Command    | Syntax                                   | Description                                                   |
-| ---------- | ---------------------------------------- | ------------------------------------------------------------- |
-| `open`     | `cypress-cli open [url] [options]`       | Start or reuse a session, launch Cypress, and navigate to URL |
-| `stop`     | `cypress-cli stop`                       | Stop the current session                                      |
-| `status`   | `cypress-cli status`                     | Check if a session is running and return session metadata     |
-| `install`  | `cypress-cli install --skills`           | Install bundled AI agent skills into `.github/skills/`        |
-| `snapshot` | `cypress-cli snapshot [--filename path]` | Get current aria snapshot                                     |
+| Command      | Syntax                                   | Description                                                   |
+| ------------ | ---------------------------------------- | ------------------------------------------------------------- |
+| `open`       | `cypress-cli open [url] [options]`       | Start or reuse a session, launch Cypress, and navigate to URL |
+| `repl`       | `cypress-cli repl`                       | Start interactive REPL mode                                   |
+| `stop`       | `cypress-cli stop`                       | Stop the current session                                      |
+| `status`     | `cypress-cli status`                     | Check if a session is running and return session metadata     |
+| `install`    | `cypress-cli install --skills`           | Install bundled AI agent skills into `.github/skills/`        |
+| `snapshot`   | `cypress-cli snapshot [--filename path]` | Get current aria snapshot                                     |
+| `console`    | `cypress-cli console [level] [--clear]`  | Return captured browser console messages                      |
+| `screenshot` | `cypress-cli screenshot [ref]`           | Capture a page or element screenshot                          |
 
 ### Navigation
 
@@ -54,20 +59,26 @@ or require a running Cypress session.
 
 ### Interaction
 
-| Command      | Syntax                                 | Description                                                |
-| ------------ | -------------------------------------- | ---------------------------------------------------------- |
-| `click`      | `cypress-cli click <ref>`              | Click element (`cy.get(sel).click()`)                      |
-| `dblclick`   | `cypress-cli dblclick <ref>`           | Double-click (`cy.get(sel).dblclick()`)                    |
-| `rightclick` | `cypress-cli rightclick <ref>`         | Right-click (`cy.get(sel).rightclick()`)                   |
-| `type`       | `cypress-cli type <ref> <text>`        | Type text (`cy.get(sel).type(text)`)                       |
-| `clear`      | `cypress-cli clear <ref>`              | Clear input (`cy.get(sel).clear()`)                        |
-| `check`      | `cypress-cli check <ref>`              | Check checkbox/radio (`cy.get(sel).check()`)               |
-| `uncheck`    | `cypress-cli uncheck <ref>`            | Uncheck checkbox (`cy.get(sel).uncheck()`)                 |
-| `select`     | `cypress-cli select <ref> <value>`     | Select option (`cy.get(sel).select(value)`)                |
-| `focus`      | `cypress-cli focus <ref>`              | Focus element (`cy.get(sel).focus()`)                      |
-| `blur`       | `cypress-cli blur <ref>`               | Blur element (`cy.get(sel).blur()`)                        |
-| `scrollto`   | `cypress-cli scrollto <ref\|position>` | Scroll (`cy.get(sel).scrollIntoView()` or `cy.scrollTo()`) |
-| `hover`      | `cypress-cli hover <ref>`              | Trigger hover (`cy.get(sel).trigger('mouseover')`)         |
+| Command          | Syntax                                 | Description                                                |
+| ---------------- | -------------------------------------- | ---------------------------------------------------------- |
+| `click`          | `cypress-cli click <ref>`              | Click element (`cy.get(sel).click()`)                      |
+| `dblclick`       | `cypress-cli dblclick <ref>`           | Double-click (`cy.get(sel).dblclick()`)                    |
+| `rightclick`     | `cypress-cli rightclick <ref>`         | Right-click (`cy.get(sel).rightclick()`)                   |
+| `type`           | `cypress-cli type <ref> <text>`        | Type text (`cy.get(sel).type(text)`)                       |
+| `fill`           | `cypress-cli fill <ref> <text>`        | Clear and type text (`cy.get(sel).clear().type(text)`)     |
+| `clear`          | `cypress-cli clear <ref>`              | Clear input (`cy.get(sel).clear()`)                        |
+| `check`          | `cypress-cli check <ref>`              | Check checkbox/radio (`cy.get(sel).check()`)               |
+| `uncheck`        | `cypress-cli uncheck <ref>`            | Uncheck checkbox (`cy.get(sel).uncheck()`)                 |
+| `select`         | `cypress-cli select <ref> <value>`     | Select option (`cy.get(sel).select(value)`)                |
+| `focus`          | `cypress-cli focus <ref>`              | Focus element (`cy.get(sel).focus()`)                      |
+| `blur`           | `cypress-cli blur <ref>`               | Blur element (`cy.get(sel).blur()`)                        |
+| `scrollto`       | `cypress-cli scrollto <ref\|position>` | Scroll (`cy.get(sel).scrollIntoView()` or `cy.scrollTo()`) |
+| `hover`          | `cypress-cli hover <ref>`              | Trigger hover (`cy.get(sel).trigger('mouseover')`)         |
+| `drag`           | `cypress-cli drag <startRef> <endRef>` | Drag one element onto another                              |
+| `upload`         | `cypress-cli upload <ref> <file>`      | Upload a file through a file input                         |
+| `dialog-accept`  | `cypress-cli dialog-accept [text]`     | Accept the next browser dialog                             |
+| `dialog-dismiss` | `cypress-cli dialog-dismiss`           | Dismiss the next browser dialog                            |
+| `resize`         | `cypress-cli resize <width> <height>`  | Change the browser viewport size                           |
 
 ### Keyboard
 
@@ -126,6 +137,8 @@ or require a running Cypress session.
 | `cookie-set`            | `cypress-cli cookie-set <name> <value> [--domain d] [--httpOnly] [--secure] [--path p]`         | Set a cookie (`cy.setCookie()`)                                |
 | `cookie-delete`         | `cypress-cli cookie-delete <name>`                                                               | Delete a cookie by name (`cy.clearCookie()`)                   |
 | `cookie-clear`          | `cypress-cli cookie-clear`                                                                       | Clear all cookies (`cy.clearCookies()`)                        |
+| `state-save`            | `cypress-cli state-save [filename]`                                                              | Save cookies, localStorage, and sessionStorage to JSON         |
+| `state-load`            | `cypress-cli state-load <filename>`                                                              | Load cookies, localStorage, and sessionStorage from JSON       |
 | `localstorage-list`     | `cypress-cli localstorage-list`                                                                  | List all localStorage entries as JSON                          |
 | `localstorage-get`      | `cypress-cli localstorage-get <key>`                                                             | Get a localStorage value by key                                |
 | `localstorage-set`      | `cypress-cli localstorage-set <key> <value>`                                                     | Set a localStorage key-value pair                              |

--- a/docs/LAUNCH_PLAN.md
+++ b/docs/LAUNCH_PLAN.md
@@ -5,8 +5,8 @@
 ## Current State (2026-04-10)
 
 - **Version:** 0.1.0
-- **Commands:** 64 implemented (68 registry entries with aliases)
-- **Tests:** 1009 passing across 52 files
+- **Commands:** 65 implemented (69 registry entries with aliases)
+- **Tests:** 1012 passing across 52 files
 - **CI:** GitHub Actions (ci.yml + e2e.yml), both green
 - **License:** MIT
 - **Package size:** 175 kB (well under npm limits)

--- a/docs/LAUNCH_PLAN.md
+++ b/docs/LAUNCH_PLAN.md
@@ -1,0 +1,323 @@
+# cypress-cli 1.0 Launch Plan
+
+> Plan for shipping v1.0.0 and getting visibility for the project.
+
+## Current State (2026-04-10)
+
+- **Version:** 0.1.0
+- **Commands:** 64 implemented (68 registry entries with aliases)
+- **Tests:** 1009 passing across 52 files
+- **CI:** GitHub Actions (ci.yml + e2e.yml), both green
+- **License:** MIT
+- **Package size:** 175 kB (well under npm limits)
+- **Open PRs:** 0
+- **Open issues:** 5 (all P1-testing or P3 — no blockers)
+
+### Open Issues
+
+| #    | Title                                            | Priority | 1.0 Blocker? |
+| ---- | ------------------------------------------------ | -------- | ------------ |
+| #73  | Long-running real-world validation comparison    | P1       | **Yes**      |
+| #62  | Keyboard/mouse primitives                        | P3       | No           |
+| #63  | delete-data and browser config on open           | P3       | No           |
+| #64  | AI agent end-to-end test harness                 | P3       | No           |
+| #113 | Refactor: extract executeCommand from driverSpec | P3       | No           |
+
+---
+
+## Phase 1: Pre-Release (1–2 days)
+
+### 1.1 Resolve the one blocker: #73 LLM validation
+
+Run a real end-to-end test-generation session using an LLM (Claude, GPT-4, etc.)
+against at least 3 different sites. Document:
+
+- Sites tested (e.g., TodoMVC, a login form, a multi-page wizard)
+- Commands used per session
+- Exported test file — does it pass `cypress-cli run`?
+- Pain points found → file as new issues or fix inline
+- Side-by-side notes vs playwright-cli (if applicable)
+
+Capture results in `validation/LLM_VALIDATION_RESULTS.md`. This is the final
+confidence gate before tagging 1.0.
+
+### 1.2 Version bump & changelog
+
+- [ ] Bump `package.json` version to `1.0.0`
+- [ ] Create `CHANGELOG.md` with a summary of all features since 0.1.0
+  - Group by: Core, Navigation, Interaction, Assertions, Network, Storage,
+    DevTools, Execution, Export, Infrastructure
+- [ ] Audit `README.md` — ensure install instructions reference the published
+      npm package name, not local paths
+- [ ] Verify `"files"` field in `package.json` includes everything needed
+      (`dist/`, `bin/`, `skills/`, `README.md`, `LICENSE`, `THIRD_PARTY_LICENSES`)
+- [ ] Run `npm pack` and inspect the tarball contents
+
+### 1.3 Final checks
+
+```bash
+npx tsc --noEmit
+npx vitest run
+npx eslint src/ tests/
+npm run build
+npm pack --dry-run
+```
+
+### 1.4 Label open P3 issues
+
+Add a `post-1.0` label to #62, #63, #64, #113 so they're clearly deferred.
+
+---
+
+## Phase 2: Release (1 day)
+
+### 2.1 npm publish
+
+```bash
+# Ensure you're logged in
+npm whoami
+# Dry run first
+npm publish --dry-run
+# Publish
+npm publish --access public
+```
+
+**Note:** The package name `cypress-cli` may be taken on npm. Check availability
+first (`npm view cypress-cli`). If taken, consider:
+
+- `@kylehgc/cypress-cli` (scoped)
+- `cypress-agent-cli`
+- `cy-cli`
+
+### 2.2 GitHub release
+
+- [ ] Tag: `git tag v1.0.0 && git push origin v1.0.0`
+- [ ] Create GitHub Release from the tag
+  - Title: `cypress-cli v1.0.0`
+  - Body: paste the CHANGELOG content for 1.0
+  - Attach nothing (npm is the distribution channel)
+
+### 2.3 Optional: GitHub Actions release workflow
+
+Add a `.github/workflows/release.yml` that auto-publishes to npm on version
+tags:
+
+```yaml
+name: Release
+on:
+  push:
+    tags: ['v*']
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          registry-url: https://registry.npmjs.org
+      - run: npm ci
+      - run: npm run build
+      - run: npm test
+      - run: npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+```
+
+---
+
+## Phase 3: Visibility & Showcasing (1–2 weeks)
+
+### 3.1 README polish
+
+The README is the #1 landing page. It needs:
+
+- [ ] **Hero section:** One-sentence pitch + animated GIF/asciicast showing
+      `open → snapshot → click → type → assert → export` flow
+- [ ] **"Why cypress-cli?"** section:
+  - LLMs can drive real Cypress commands through a simple CLI
+  - Aria snapshots give compact, semantic DOM representation
+  - Every session exports to a runnable `.cy.ts` test
+  - 65 commands covering navigation, interaction, assertions, network, storage
+- [ ] **Comparison table** vs playwright-cli (already in ROADMAP.md — extract
+      key rows)
+- [ ] **AI Agent integration** section with the SKILL file workflow:
+  ```bash
+  cypress-cli install --skills
+  ```
+- [ ] **Badges:** npm version, CI status, license, Node version
+
+### 3.2 Create a demo recording
+
+Record a terminal session (using [asciinema](https://asciinema.org/) or
+[VHS](https://github.com/charmbracelet/vhs)) showing:
+
+1. `cypress-cli open https://todomvc.com/examples/react/dist/`
+2. `cypress-cli snapshot` — show the aria tree
+3. `cypress-cli type e5 "Write launch plan"`
+4. `cypress-cli press Enter`
+5. `cypress-cli snapshot` — show the todo appeared
+6. `cypress-cli assert e10 have.text "Write launch plan"`
+7. `cypress-cli export --file todo.cy.ts`
+8. `cypress-cli run todo.cy.ts` — show it passes
+9. `cypress-cli stop`
+
+This becomes the hero GIF in the README and the demo for all promotion.
+
+### 3.3 Blog post / announcement
+
+Write a launch post covering:
+
+- **Problem:** LLMs need browser access for test generation, but existing tools
+  target Playwright. Cypress users are left out.
+- **Solution:** cypress-cli gives LLMs REPL-like access to a live browser through
+  real Cypress commands, with aria snapshot output.
+- **Architecture highlight:** The cy.task() polling loop + QueueBridge approach
+  that makes Cypress work as an interactive tool despite its non-interactive
+  design.
+- **Demo:** Embed the terminal recording.
+- **Comparison:** Feature parity with playwright-cli (65 commands, same CLI +
+  SKILLS model).
+- **Call to action:** `npm install -g cypress-cli` + link to repo.
+
+### 3.4 Distribution channels
+
+#### Primary (day of release)
+
+| Channel                 | Action                                                                                              |
+| ----------------------- | --------------------------------------------------------------------------------------------------- |
+| **Hacker News**         | "Show HN: cypress-cli — Give LLMs REPL access to a browser through Cypress commands"                |
+| **Reddit r/javascript** | Post with demo GIF + 2-paragraph description                                                        |
+| **Reddit r/webdev**     | Same post, emphasize testing angle                                                                  |
+| **Reddit r/cypress**    | Targeted post for Cypress community                                                                 |
+| **Twitter/X**           | Thread: problem → solution → demo GIF → link. Tag @Abortedbrain (Cypress), @plaabortwrightdev, etc. |
+| **Dev.to**              | Cross-post the blog post                                                                            |
+| **LinkedIn**            | Personal post with demo + link                                                                      |
+
+#### Secondary (week after release)
+
+| Channel                          | Action                                                         |
+| -------------------------------- | -------------------------------------------------------------- |
+| **Cypress Discord / Community**  | Share in #show-and-tell or equivalent                          |
+| **GitHub Discussions (Cypress)** | Create a discussion in cypress-io/cypress about the tool       |
+| **AI coding agent communities**  | Post in Cursor, Cline, Aider, Claude forums                    |
+| **npm "awesome" lists**          | PR to awesome-cypress, awesome-testing-tools                   |
+| **YouTube**                      | 5-min walkthrough video (optional, high-effort but high-reach) |
+
+### 3.5 AI agent ecosystem integration
+
+This is the highest-leverage visibility channel — if AI coding agents discover
+and use the tool natively, adoption grows organically.
+
+- [ ] **Ensure SKILL.md is discoverable:** The `install --skills` command
+      already copies it to `.github/skills/cypress-cli/`. Verify this works with
+      the major agents (Copilot, Claude Code, Cursor).
+- [ ] **Open PRs to agent tool directories:**
+  - Cursor: community tools/MCP directory
+  - Claude: tool-use examples
+  - Cline: tool integration docs
+- [ ] **Create example prompts** showing LLMs how to use cypress-cli:
+  - "Generate a Cypress test for the login flow on [url]"
+  - "Verify that the checkout process works end-to-end"
+  - "Test all form validations on this page"
+- [ ] **Publish the SKILL.md approach** as a pattern other tools can follow
+
+### 3.6 Launch website
+
+Build a single-page landing site at **cypress-cli.dev** (or GitHub Pages at
+`kylehgc.github.io/cypress-cli`). This is the link you share everywhere — HN,
+Reddit, Twitter, blog posts. A GitHub repo README alone doesn't convert
+drive-by visitors.
+
+**Stack:** Static site — Astro Starlight, VitePress, or even a single
+`index.html` with Tailwind. Host on GitHub Pages (free, zero-config with
+Actions). No backend needed.
+
+**Sections:**
+
+- [ ] **Hero:** One-liner pitch + `npm install -g cypress-cli` + embedded
+      asciinema/VHS terminal recording of the full open→snapshot→interact→export→run
+      flow
+- [ ] **How it works:** 3-step diagram (CLI sends command → Cypress executes in
+      real browser → aria snapshot returned). Reuse the architecture diagram from
+      `ARCHITECTURE.md`
+- [ ] **For AI agents:** Show the SKILL file workflow — `install --skills`,
+      then the LLM auto-discovers commands. Embed an example prompt + response
+- [ ] **Command reference:** Searchable/filterable table of all 65 commands
+      with examples (auto-generate from `docs/COMMANDS.md`)
+- [ ] **vs playwright-cli:** Side-by-side comparison table. Honest about
+      limitations (no multi-tab, no PDF). Emphasize: same CLI+SKILLS model, but
+      generates Cypress tests
+- [ ] **Getting started:** 60-second quickstart with copy-paste commands
+- [ ] **Footer:** GitHub link, npm link, license, "Built by @kylehgc"
+
+**Why this matters:**
+
+- Every social media post needs a destination URL that's not a raw GitHub repo
+- A polished landing page signals "real project" vs "weekend experiment"
+- The embedded terminal demo lets people see it work without installing anything
+- The command reference becomes the canonical docs people bookmark
+- SEO: "cypress cli llm" / "cypress test generation ai" queries will land here
+
+**Effort:** ~1 day with a static site generator. The content already exists in
+README.md, COMMANDS.md, ROADMAP.md, and ARCHITECTURE.md — it's mostly
+reformatting.
+
+### 3.7 Full documentation site (post-launch, if traction)
+
+If the tool gains traction beyond the landing page, expand into a multi-page
+docs site with:
+
+- Getting started guide
+- Command reference (auto-generated from COMMANDS.md)
+- AI agent integration guide
+- Architecture deep-dive
+- Contributing guide
+
+---
+
+## Phase 4: Post-Launch (ongoing)
+
+### 4.1 Monitor & respond
+
+- [ ] Watch GitHub issues for user-reported bugs — triage within 24h
+- [ ] Monitor npm download stats
+- [ ] Respond to HN/Reddit comments on launch day
+- [ ] Track which AI agents are actually using the tool (via GitHub search for
+      SKILL.md references)
+
+### 4.2 Fast-follow releases (v1.1, v1.2)
+
+Queue these based on user feedback and open issues:
+
+| Version | Candidates                                               |
+| ------- | -------------------------------------------------------- |
+| v1.1    | #63 (delete-data + browser config), #62 (keyboard/mouse) |
+| v1.2    | #113 (driverSpec refactor), #64 (AI test harness)        |
+| v1.x    | User-requested features, bug fixes from real-world usage |
+
+### 4.3 Metrics to track
+
+| Metric                          | Target (3 months) | How to measure                   |
+| ------------------------------- | ----------------- | -------------------------------- |
+| npm weekly downloads            | 500+              | npm stats                        |
+| GitHub stars                    | 200+              | GitHub                           |
+| Open issues from external users | 10+               | GitHub issues (non-kylehgc)      |
+| AI agent integrations           | 2+                | GitHub search for SKILL.md usage |
+| Contributed PRs                 | 3+                | GitHub PRs from non-kylehgc      |
+
+---
+
+## Timeline Summary
+
+| Phase               | Duration | Key Deliverable                         |
+| ------------------- | -------- | --------------------------------------- |
+| Pre-Release         | 1–2 days | LLM validation, version bump, CHANGELOG |
+| Release             | 1 day    | npm publish, GitHub release tag         |
+| Launch site + demo  | 1 day    | Landing page + terminal recording       |
+| Visibility (wave 1) | Day of   | HN, Reddit, Twitter, blog post          |
+| Visibility (wave 2) | Week 1   | Discord, agent ecosystems, lists        |
+| Post-Launch         | Ongoing  | Bug triage, fast-follow releases        |

--- a/docs/LLM_VALIDATION_RUNBOOK.md
+++ b/docs/LLM_VALIDATION_RUNBOOK.md
@@ -1,0 +1,578 @@
+# LLM Validation Runbook — Step-by-Step Instructions
+
+> **Audience:** An LLM agent executing the 1.0 launch validation (§1.1 of
+> `docs/LAUNCH_PLAN.md`, issue #73).
+>
+> **Rule:** After completing each numbered step, you MUST:
+>
+> 1. Re-read `docs/LAUNCH_PLAN.md` in full
+> 2. Re-read `validation/LLM_VALIDATION_LOG.md` (the log you're maintaining)
+> 3. Append an entry to the log with your observations, problems found, and
+>    any suggested changes to the launch plan
+>
+> This is not optional. The log is the primary deliverable alongside the
+> validation itself.
+
+---
+
+## Before You Start
+
+### 0.1 Read all project documentation
+
+Read every one of these files. Do not skim. Understand what this project is,
+how it works, how commands flow, and what the existing validation found.
+
+**Required reading (read in this order):**
+
+1. `AGENTS.md` — project overview, repo layout, check commands, workflow
+2. `CONVENTIONS.md` — code style, naming, error handling
+3. `ARCHITECTURE.md` — system design, data flow, component diagram
+4. `docs/COMMANDS.md` — all 65 public commands, schemas, Cypress API mappings
+5. `docs/ROADMAP.md` — feature parity tracking, known limitations vs playwright-cli
+6. `docs/CAPABILITY_MATRIX.md` — per-command feasibility classification
+7. `docs/LIVE_VALIDATION.md` — how to validate, expected output format
+8. `docs/LAUNCH_PLAN.md` — the plan you are executing (§1.1 specifically)
+9. `validation/README.md` — existing scenario descriptions
+10. `validation/FINDINGS.md` — previous validation results (4 sites, 73 steps)
+11. `validation/scenarios/01-todomvc.md` — scenario 1 detail
+12. `validation/scenarios/02-saucedemo.md` — scenario 2 detail
+13. `validation/scenarios/03-the-internet.md` — scenario 3 detail
+14. `validation/scenarios/04-realworld-conduit.md` — scenario 4 detail
+15. `validation/examples/todomvc.cy.ts` — generated test from scenario 1
+16. `validation/examples/saucedemo.cy.ts` — generated test from scenario 2
+17. `validation/examples/the-internet.cy.ts` — generated test from scenario 3
+18. `README.md` — the public-facing README
+19. `skills/cypress-cli/SKILL.md` — the AI agent skill definition
+20. `docs/PACKAGE_SPEC.md` — package.json structure, build config
+
+After reading all files, proceed to Step 0.2.
+
+### 0.2 Create the validation log
+
+Create the file `validation/LLM_VALIDATION_LOG.md` with this initial content:
+
+```markdown
+# LLM Validation Log
+
+> Running log maintained during the 1.0 validation runbook.
+> Each entry is appended after completing a step from `docs/LLM_VALIDATION_RUNBOOK.md`.
+
+## Format
+
+Each entry follows this structure:
+
+### Step N.N — [Step Title] — [YYYY-MM-DD HH:MM]
+
+**Status:** Pass / Fail / Partial / Blocked
+
+**Observations:**
+
+- [What happened]
+
+**Problems Found:**
+
+- [Description] → [Severity: blocker / should-fix / nice-to-have] → [Action: filed #N / fixed inline / deferred]
+
+**Launch Plan Notes:**
+
+- [Any observations about `docs/LAUNCH_PLAN.md` — is anything missing, wrong, or needs updating?]
+
+---
+
+## Entries
+```
+
+### 0.3 Log your initial observations
+
+Now re-read `docs/LAUNCH_PLAN.md` and `validation/LLM_VALIDATION_LOG.md`.
+
+Append your first log entry:
+
+```
+### Step 0 — Documentation Review — [timestamp]
+
+**Status:** Complete
+
+**Observations:**
+- [Summarize your understanding of the project]
+- [Note any gaps, contradictions, or unclear areas in the docs]
+- [Note the current state: how many commands, tests, what's already validated]
+
+**Problems Found:**
+- [Any issues spotted during doc review]
+
+**Launch Plan Notes:**
+- [Initial thoughts on the plan — does it miss anything?]
+- [Is the timeline realistic given what you've read?]
+```
+
+---
+
+## Step 1: Build and Verify Baseline
+
+### 1.1 Build the project
+
+```bash
+npm run build
+```
+
+Confirm it succeeds with zero errors. If it fails, diagnose and fix before
+proceeding — nothing else will work without a clean build.
+
+### 1.2 Run the full test suite
+
+```bash
+npx vitest run
+```
+
+Record: total tests, pass count, fail count, test file count.
+
+### 1.3 Run type checking and lint
+
+```bash
+npx tsc --noEmit
+npx eslint src/ tests/
+```
+
+Both must pass with zero errors and zero warnings.
+
+### 1.4 Log entry
+
+Re-read `docs/LAUNCH_PLAN.md` and `validation/LLM_VALIDATION_LOG.md`.
+Append a log entry for Step 1 with the test counts, any issues, and whether
+the baseline matches what `docs/READINESS_ASSESSMENT.md` claims (1012 tests,
+0 errors, 0 warnings).
+
+---
+
+## Step 2: Validate Existing Scenarios (Re-run)
+
+The previous validation (`validation/FINDINGS.md`) was run when only 43
+commands existed. The project now has 65 commands. Re-run the existing
+scenarios to confirm they still work with the current codebase.
+
+### 2.1 Scenario 1: TodoMVC
+
+Read `validation/scenarios/01-todomvc.md`. Execute every step against the live
+site. For each step:
+
+- Run the command exactly as specified
+- Verify the output matches expected format (`### Page` + `### Snapshot`)
+- Read the snapshot file and confirm refs make sense
+- If a step fails, note the exact error and whether it's a tool bug or site change
+
+After all steps, run `export` and save the generated test.
+
+Then run the exported test:
+
+```bash
+node bin/cypress-cli run <exported-file>
+```
+
+Record whether it passes.
+
+### 2.2 Log entry
+
+Re-read `docs/LAUNCH_PLAN.md` and `validation/LLM_VALIDATION_LOG.md`.
+Append a log entry for Step 2.1 with per-step results.
+
+### 2.3 Scenario 2: SauceDemo
+
+Read `validation/scenarios/02-saucedemo.md`. Execute every step. Same procedure
+as 2.1.
+
+### 2.4 Log entry
+
+Re-read both files. Append log entry for Step 2.3.
+
+### 2.5 Scenario 3: The Internet
+
+Read `validation/scenarios/03-the-internet.md`. Execute every step. Same
+procedure. This is the broadest scenario (30 commands across many page types).
+
+### 2.6 Log entry
+
+Re-read both files. Append log entry for Step 2.5.
+
+### 2.7 Scenario 4: RealWorld Conduit
+
+Read `validation/scenarios/04-realworld-conduit.md`. Execute every step. Note
+that the previous run found the backend API was down (530 errors). If still
+down, note that and proceed — focus on the steps that don't require a live API.
+
+### 2.8 Log entry
+
+Re-read both files. Append log entry for Step 2.7.
+
+---
+
+## Step 3: Test NEW Commands Not Covered by Existing Scenarios
+
+The previous validation (43 commands) did not cover commands added since then.
+The following commands need explicit validation. Design and execute a mini-test
+for each group against appropriate live sites.
+
+### 3.1 Storage commands
+
+Use `https://example.cypress.io/commands/actions` or any site that uses
+localStorage/sessionStorage.
+
+```bash
+# Open session
+node bin/cypress-cli open <url>
+
+# localStorage
+node bin/cypress-cli localstorage-set testKey testValue
+node bin/cypress-cli localstorage-get testKey
+node bin/cypress-cli localstorage-list
+node bin/cypress-cli localstorage-delete testKey
+node bin/cypress-cli localstorage-list  # confirm empty
+
+# sessionStorage
+node bin/cypress-cli sessionstorage-set sessKey sessValue
+node bin/cypress-cli sessionstorage-get sessKey
+node bin/cypress-cli sessionstorage-list
+node bin/cypress-cli sessionstorage-delete sessKey
+node bin/cypress-cli sessionstorage-clear
+
+# State save/load
+node bin/cypress-cli cookie-set myCook testVal
+node bin/cypress-cli localstorage-set myKey myVal
+node bin/cypress-cli state-save
+# Navigate away, clear state
+node bin/cypress-cli navigate https://example.com
+node bin/cypress-cli cookie-clear
+node bin/cypress-cli localstorage-clear
+# Restore
+node bin/cypress-cli state-load
+node bin/cypress-cli cookie-get myCook
+node bin/cypress-cli localstorage-get myKey
+```
+
+Verify each command returns expected output.
+
+### 3.2 Log entry
+
+Re-read both files. Append log entry for Step 3.1.
+
+### 3.3 Console command
+
+```bash
+node bin/cypress-cli open https://example.cypress.io
+node bin/cypress-cli run-code "console.log('hello from validation')"
+node bin/cypress-cli console
+```
+
+Verify the console output includes the logged message.
+
+### 3.4 Log entry
+
+Re-read both files. Append log entry for Step 3.3.
+
+### 3.5 Network commands
+
+```bash
+node bin/cypress-cli open https://jsonplaceholder.typicode.com
+node bin/cypress-cli network
+node bin/cypress-cli intercept '**/posts' --status 200 --body '[]'
+node bin/cypress-cli intercept-list
+node bin/cypress-cli navigate https://jsonplaceholder.typicode.com/posts
+node bin/cypress-cli network
+node bin/cypress-cli unintercept '**/posts'
+node bin/cypress-cli intercept-list  # confirm empty
+```
+
+### 3.6 Log entry
+
+Re-read both files. Append log entry for Step 3.5.
+
+### 3.7 Execution commands (cyrun, run-code, eval)
+
+```bash
+node bin/cypress-cli open https://example.cypress.io/commands/actions
+node bin/cypress-cli eval "document.title"
+node bin/cypress-cli run-code "document.querySelectorAll('input').length"
+node bin/cypress-cli cyrun "cy.url().then(u => u)"
+```
+
+Verify each returns a sensible result.
+
+### 3.8 Log entry
+
+Re-read both files. Append log entry for Step 3.7.
+
+### 3.9 Run command (test execution)
+
+Export from the current session and run it:
+
+```bash
+node bin/cypress-cli export --file /tmp/validation-test.cy.ts
+node bin/cypress-cli run /tmp/validation-test.cy.ts
+```
+
+Verify the run command returns structured results (pass/fail, test count,
+duration).
+
+### 3.10 Log entry
+
+Re-read both files. Append log entry for Step 3.9.
+
+### 3.11 REPL mode
+
+```bash
+node bin/cypress-cli repl
+```
+
+Inside the REPL, run at least 5 commands:
+
+```
+> open https://example.cypress.io
+> snapshot
+> click e5
+> history
+> stop
+```
+
+Verify REPL input/output works, quoting is handled, and `stop` exits cleanly.
+
+### 3.12 Log entry
+
+Re-read both files. Append log entry for Step 3.11.
+
+---
+
+## Step 4: Error Recovery Validation
+
+Test that the tool survives bad input gracefully. The LLM experience depends
+heavily on error messages being actionable.
+
+### 4.1 Bad ref
+
+```bash
+node bin/cypress-cli open https://example.cypress.io
+node bin/cypress-cli click e99999
+```
+
+Verify: session stays alive, error message mentions the invalid ref, and a
+subsequent `snapshot` command still works.
+
+### 4.2 Invalid command arguments
+
+```bash
+node bin/cypress-cli assert  # missing required args
+node bin/cypress-cli type    # missing ref and text
+node bin/cypress-cli navigate  # missing url
+```
+
+Verify: each returns a clear error, not a crash.
+
+### 4.3 Command after session stop
+
+```bash
+node bin/cypress-cli stop
+node bin/cypress-cli snapshot
+```
+
+Verify: clear error message about no active session.
+
+### 4.4 Double open
+
+```bash
+node bin/cypress-cli open https://example.cypress.io
+node bin/cypress-cli open https://example.com
+```
+
+Verify: second open either reuses or cleanly replaces the session.
+
+### 4.5 Log entry
+
+Re-read both files. Append log entry for Step 4 (all sub-steps).
+
+---
+
+## Step 5: Export Quality Audit
+
+### 5.1 Run a comprehensive session
+
+Open a site with diverse interactions. Execute at least 15 commands covering:
+
+- Navigation (`open`, `navigate`)
+- Form interaction (`type`, `fill`, `clear`, `select`, `check`)
+- Assertions (`assert`, `asserturl`, `asserttitle`)
+- Wait patterns (`waitfor`)
+- Screenshots (`screenshot`)
+
+### 5.2 Export and review the generated test
+
+```bash
+node bin/cypress-cli export --file /tmp/comprehensive.cy.ts
+```
+
+Read the exported file. Check:
+
+- [ ] Valid TypeScript syntax
+- [ ] `describe()` and `it()` structure
+- [ ] Correct Cypress commands (`.type()`, `.click()`, `.should()`, etc.)
+- [ ] Selectors look reasonable (not overly fragile)
+- [ ] No meta-commands leaked (no `snapshot`, `history`, `status` in output)
+- [ ] `baseUrl` handling (if applicable)
+- [ ] Imports and test boilerplate
+
+### 5.3 Run the exported test
+
+```bash
+node bin/cypress-cli run /tmp/comprehensive.cy.ts
+```
+
+Record pass/fail. If it fails, diagnose whether it's a codegen issue or a
+site timing issue.
+
+### 5.4 Log entry
+
+Re-read both files. Append log entry for Step 5.
+
+---
+
+## Step 6: SKILL File and Agent Discoverability
+
+### 6.1 Test skill installation
+
+```bash
+# Clean slate
+rm -rf .github/skills/cypress-cli
+
+# Install
+node bin/cypress-cli install --skills
+
+# Verify
+ls -la .github/skills/cypress-cli/
+cat .github/skills/cypress-cli/SKILL.md
+```
+
+Verify the SKILL.md is installed correctly and contains accurate command docs.
+
+### 6.2 Review SKILL.md accuracy
+
+Compare `skills/cypress-cli/SKILL.md` against the actual command set in
+`docs/COMMANDS.md`. Check:
+
+- [ ] All 65 commands are listed or at least the most important ones
+- [ ] Command syntax examples are accurate
+- [ ] The "how to read snapshots" section matches actual output format
+- [ ] No stale references to removed or renamed commands
+
+### 6.3 Log entry
+
+Re-read both files. Append log entry for Step 6.
+
+---
+
+## Step 7: README and Package Audit
+
+### 7.1 README accuracy check
+
+Read `README.md` and verify:
+
+- [ ] Install instructions work (`npm install -g cypress-cli`)
+- [ ] Quick start commands match actual behavior
+- [ ] Command table is complete and accurate
+- [ ] No broken links
+- [ ] Version references are consistent
+
+### 7.2 Package contents check
+
+```bash
+npm pack --dry-run
+```
+
+Verify the output includes: `dist/`, `bin/cypress-cli`, `skills/`, `README.md`,
+`LICENSE`, `THIRD_PARTY_LICENSES`. Check nothing unexpected is included
+(no `tests/`, no `node_modules/`, no `.github/`).
+
+### 7.3 Log entry
+
+Re-read both files. Append log entry for Step 7.
+
+---
+
+## Step 8: Final Assessment
+
+### 8.1 Re-read everything
+
+Read all of these one final time:
+
+1. `docs/LAUNCH_PLAN.md`
+2. `validation/LLM_VALIDATION_LOG.md` (your full log)
+3. `validation/FINDINGS.md` (previous validation)
+4. `docs/READINESS_ASSESSMENT.md`
+
+### 8.2 Write the final results document
+
+Create `validation/LLM_VALIDATION_RESULTS.md` with:
+
+```markdown
+# LLM Validation Results — 1.0 Gate
+
+**Date:** [YYYY-MM-DD]
+**Agent:** [Your model name]
+**Codebase:** 65 commands, [N] tests
+
+## Summary
+
+| Category                   | Steps | Pass | Fail | Blocked |
+| -------------------------- | ----- | ---- | ---- | ------- |
+| Scenario re-runs (4 sites) |       |      |      |         |
+| New command validation     |       |      |      |         |
+| Error recovery             |       |      |      |         |
+| Export quality             |       |      |      |         |
+| Skill & package audit      |       |      |      |         |
+| **Total**                  |       |      |      |         |
+
+## Blockers Found
+
+[List any issues that MUST be fixed before 1.0, or "None"]
+
+## Should-Fix Issues
+
+[List issues that should be fixed but aren't blockers]
+
+## Launch Plan Observations
+
+[Summarize all your notes about `docs/LAUNCH_PLAN.md` from the log entries.
+Include suggested changes, missing items, timeline concerns, etc.]
+
+## Verdict
+
+**[READY / NOT READY] for 1.0 release.**
+
+[Reasoning in 2-3 sentences]
+```
+
+### 8.3 Final log entry
+
+Re-read both files. Append your final log entry with the verdict and a summary
+of the full run.
+
+### 8.4 Clean up
+
+```bash
+node bin/cypress-cli stop  # if session is still active
+```
+
+---
+
+## Reminders
+
+- **Re-read the launch plan and your log after EVERY step.** This is the whole
+  point — the log is a living document of observations that feeds back into
+  launch readiness.
+- **Don't skip steps because "it probably works."** The previous validation
+  found 0 failures across 73 steps but also found 2 workarounds and a dead
+  backend. Real surprises only show up when you actually execute.
+- **If you find a bug:** Fix it inline if it's small (< 20 lines). If it's
+  larger, file a GitHub issue with reproduction steps and note it in your log
+  as a blocker or should-fix.
+- **If a site is down:** Note it in the log and substitute a different
+  publicly accessible site that exercises similar commands.
+- **Time yourself loosely.** Note how long each step group takes — this data
+  is useful for estimating Phase 1 duration in the launch plan.

--- a/docs/NEXT_STEPS_PLAN.md
+++ b/docs/NEXT_STEPS_PLAN.md
@@ -1,0 +1,342 @@
+# Next Steps Plan — Tasks 1–3
+
+> Step-by-step instructions for an LLM agent to complete three tasks in order.
+> Each task is a separate branch and PR. Complete one before starting the next.
+>
+> **Status (2026-04-08):** All three tasks are complete.
+
+## Rules
+
+1. **Read `AGENTS.md` before starting any task.** It contains the project
+   conventions, check commands, and PR workflow.
+2. **Read `CONVENTIONS.md` before writing any code.** It has the style rules.
+3. **All changes must be verified by manual use of the repo.** Unit tests
+   passing is not enough — you must run the CLI against a real page and confirm
+   the feature works as described in `docs/LIVE_VALIDATION.md`.
+4. **After completing each task**, re-read `AGENTS.md` to confirm you haven't
+   missed any checklist items before opening the PR.
+
+---
+
+## Task 1: Fix Flaky queueBridge Test ✅ Complete
+
+**Branch:** `fix/flaky-queue-bridge-test`
+**Closes:** n/a (no issue — this is a test reliability fix)
+
+### Problem
+
+`tests/unit/cypress/queueBridge.test.ts` — the test
+`'start() listens on a socket and stop() cleans it up'` fails intermittently.
+
+The test calls `bridge.stop()` and then immediately asserts
+`fs.access(socketPath)` rejects. But `QueueBridge.stop()` in
+`src/cypress/queueBridge.ts` closes the server and unlinks the socket file
+asynchronously — the `fs.unlink` may not have completed by the time the
+assertion runs.
+
+Additionally, the `afterEach` hook also calls `bridge.stop()`, so `stop()` is
+called twice for this test. The second call should be a no-op but confirm
+this.
+
+### Steps
+
+1. Read `src/cypress/queueBridge.ts`, focusing on the `stop()` method.
+   Understand the order of operations: server close → unlink socket.
+2. Read `tests/unit/cypress/queueBridge.test.ts` in full.
+3. Fix the race condition. The most likely fix is ensuring `stop()` properly
+   `await`s the `fs.unlink()` call (or that the test waits for the file to
+   actually be gone). Check whether `stop()` returns a promise that resolves
+   only after the unlink completes. If not, fix `stop()` so it does.
+4. Ensure calling `stop()` twice is safe (the `afterEach` will call it again).
+5. Run `npx vitest run tests/unit/cypress/queueBridge.test.ts` — must pass.
+6. Run the full check commands:
+   ```bash
+   npx tsc --noEmit
+   npx vitest run
+   npx eslint src/ tests/
+   npm run build
+   ```
+7. Commit: `fix: await socket unlink in QueueBridge.stop() to fix flaky test`
+
+### Verification
+
+Run the specific test 10 times in a row to confirm it's no longer flaky:
+
+```bash
+for i in {1..10}; do npx vitest run tests/unit/cypress/queueBridge.test.ts || break; done
+```
+
+---
+
+## Task 2: Implement `run` Command (Issue #81) ✅ Complete
+
+**Branch:** `issue-81-run-command`
+**Closes:** #81
+
+### Context
+
+The `run` command closes the generate-then-execute loop: an LLM exports a
+`.cy.ts` test file via the `export` command, then uses `run` to execute it and
+see results.
+
+Read the full issue body at: https://github.com/kylehgc/cypress-cli/issues/81
+
+### Design
+
+- `cypress-cli run <file> [--browser chrome|electron] [--headed]`
+- Launches a **separate** `cypress.run()` invocation (not the REPL session)
+- Uses standard `testIsolation: true` (normal Cypress test behavior)
+- Returns structured results: pass/fail, failure messages, duration
+- Does NOT affect the active REPL session
+
+### Steps
+
+1. **Read existing patterns:**
+   - `src/client/commands.ts` — how commands are declared with `declareCommand()`
+     and registered in `allCommands` + `buildRegistry()`.
+   - `src/cypress/launcher.ts` — has `launchCypressRun()` which uses
+     `cypress.default.run()`. The `run` command needs a similar but simpler
+     invocation that just runs a spec file normally without the REPL bridge.
+   - `src/daemon/handlers.ts` — how daemon-local commands are handled.
+   - `src/codegen/codegen.ts` and `src/codegen/templateEngine.ts` — understand
+     the export flow so `run` complements it.
+   - `docs/COMMANDS.md` — for the protocol schema pattern.
+
+2. **Declare the command schema** in `src/client/commands.ts`:
+
+   ```typescript
+   export const run = declareCommand({
+   	name: 'run',
+   	category: 'execution',
+   	description: 'Run a Cypress test file and report results',
+   	args: z.object({
+   		file: z.string().describe('Path to the test file to run'),
+   	}),
+   	options: z.object({
+   		browser: z
+   			.enum(['chrome', 'electron'])
+   			.optional()
+   			.describe('Browser to use (default: electron)'),
+   		headed: z
+   			.boolean()
+   			.optional()
+   			.describe('Run in headed mode (default: false)'),
+   	}),
+   });
+   ```
+
+3. **Add to `allCommands` and `buildRegistry()`.**
+   Update the command count test expectations in
+   `tests/unit/client/commands.test.ts` (currently 63 commands / 67 registry).
+
+4. **Implement the daemon handler** — this command is handled in the daemon
+   (not forwarded to the Cypress REPL). The handler should:
+   - Validate the file exists and has a `.cy.ts` or `.cy.js` extension.
+   - Dynamically import `cypress` and call `cypress.default.run({ spec, browser, headed })`.
+   - Map the Cypress `CypressCommandLine.CypressRunResult` to a structured
+     response: `{ success, totalTests, totalPassed, totalFailed, failures[], duration }`.
+   - Return the result as the command response.
+   - Do NOT touch the active REPL session.
+
+5. **Wire the handler** in `src/daemon/daemon.ts` — add a case for the `run`
+   command in the command dispatch. This should call the handler directly rather
+   than enqueuing it in the Cypress command queue.
+
+6. **Wire the CLI command** in `src/client/cli.ts` — ensure `run` is a
+   top-level CLI subcommand (not a REPL-session command). The user invokes it
+   as `cypress-cli run login.cy.ts`.
+
+7. **Write unit tests:**
+   - `tests/unit/client/commands.test.ts` — schema validation for the `run` command.
+   - `tests/unit/daemon/` — handler test that mocks `cypress.default.run()`.
+   - Test both success and failure result mapping.
+
+8. **Update docs/COMMANDS.md** with the new command entry.
+
+9. **Run all check commands:**
+
+   ```bash
+   npx tsc --noEmit
+   npx vitest run
+   npx eslint src/ tests/
+   npm run build
+   ```
+
+10. **Commit:** `feat: add run command for executing generated test files (closes #81)`
+
+### Verification
+
+```bash
+# 1. Open a session
+node bin/cypress-cli open https://example.cypress.io/commands/actions
+
+# 2. Do some actions
+node bin/cypress-cli click e5
+node bin/cypress-cli type e40 'test@example.com'
+
+# 3. Export a test file
+node bin/cypress-cli export --file test-actions.cy.ts
+
+# 4. Run the exported test
+node bin/cypress-cli run test-actions.cy.ts
+
+# 5. Confirm structured output: success/fail, test count, duration
+# 6. Confirm the REPL session is still active
+node bin/cypress-cli snapshot
+
+# 7. Clean up
+node bin/cypress-cli stop
+```
+
+---
+
+## Task 3: CI/CD Pipeline (Issue #15) ✅ Complete
+
+**Branch:** `issue-15-ci-cd`
+**Closes:** #15
+
+### Context
+
+Read the full issue at: https://github.com/kylehgc/cypress-cli/issues/15
+
+No `.github/workflows/` directory exists yet. A previous WIP PR (#38) was
+closed without merging — do not reuse it; start fresh.
+
+### Acceptance Criteria (from issue)
+
+- [ ] `.github/workflows/ci.yml` — lint, typecheck, unit tests, integration
+      tests on push/PR (Node 20, ubuntu-latest)
+- [ ] `.github/workflows/e2e.yml` — e2e tests on push to main (needs Cypress
+      binary, longer timeout)
+- [ ] `package.json` `files` field configured for minimal publish
+      (`dist/`, `bin/`, `LICENSE`, `README`)
+- [ ] `npm pack --dry-run` produces clean tarball under 500KB
+- [ ] `prepublishOnly` script: lint + typecheck + test + build
+- [ ] `.npmignore` or `files` whitelist excludes tests, docs, temp files
+- [ ] Renovate or Dependabot config for dependency updates
+
+### Steps
+
+1. **Read `docs/PACKAGE_SPEC.md`** for the build pipeline and package.json
+   specification.
+
+2. **Create `.github/workflows/ci.yml`:**
+
+   ```yaml
+   name: CI
+   on:
+     push:
+       branches: [main]
+     pull_request:
+       branches: [main]
+   jobs:
+     check:
+       runs-on: ubuntu-latest
+       strategy:
+         matrix:
+           node-version: [20]
+       steps:
+         - uses: actions/checkout@v4
+         - uses: actions/setup-node@v4
+           with:
+             node-version: ${{ matrix.node-version }}
+             cache: npm
+         - run: npm ci
+         - run: npx tsc --noEmit
+         - run: npx eslint src/ tests/
+         - run: npx vitest run --project unit
+         - run: npx vitest run --project integration
+   ```
+
+3. **Create `.github/workflows/e2e.yml`:**
+
+   ```yaml
+   name: E2E
+   on:
+     push:
+       branches: [main]
+   jobs:
+     e2e:
+       runs-on: ubuntu-latest
+       timeout-minutes: 20
+       steps:
+         - uses: actions/checkout@v4
+         - uses: actions/setup-node@v4
+           with:
+             node-version: 20
+             cache: npm
+         - run: npm ci
+         - run: npm run build
+         - run: npx vitest run --project e2e
+   ```
+
+4. **Update `package.json`:**
+   - Add `"files": ["dist/", "bin/", "LICENSE", "README.md"]`
+   - Add `"prepublishOnly": "npm run lint && npm run typecheck && npm test && npm run build"`
+   - Verify existing script names match (`lint`, `typecheck`, `test`, `build`).
+
+5. **Create `.github/dependabot.yml`:**
+
+   ```yaml
+   version: 2
+   updates:
+     - package-ecosystem: npm
+       directory: /
+       schedule:
+         interval: weekly
+     - package-ecosystem: github-actions
+       directory: /
+       schedule:
+         interval: weekly
+   ```
+
+6. **Verify tarball size:**
+
+   ```bash
+   npm run build
+   npm pack --dry-run 2>&1 | tail -5
+   # Must be under 500KB and only contain dist/, bin/, LICENSE, README.md
+   ```
+
+7. **Run all check commands:**
+
+   ```bash
+   npx tsc --noEmit
+   npx vitest run
+   npx eslint src/ tests/
+   npm run build
+   ```
+
+8. **Commit:** `chore: add CI/CD pipeline and release config (closes #15)`
+
+### Verification
+
+```bash
+# Verify the files field is correct
+npm pack --dry-run 2>&1
+
+# Confirm only dist/, bin/, LICENSE, README.md are included
+# Confirm tarball size is under 500KB
+
+# Verify CI workflow syntax is valid
+# (If act is installed: act -n to dry-run GitHub Actions locally)
+# Otherwise, push the branch and check the Actions tab on GitHub
+
+# Verify the prepublishOnly script works:
+npm run prepublishOnly
+```
+
+---
+
+## After Every Task
+
+After completing each task above, before committing or opening a PR:
+
+1. **Re-read `AGENTS.md`** in full — confirm every item on the PR Review
+   Checklist is satisfied.
+2. **Run all four check commands** (typecheck, test, lint, build) — all must
+   pass with zero errors.
+3. **Perform live validation** as described in `docs/LIVE_VALIDATION.md` and
+   the Verification section of each task above. Do not skip this.
+4. **Manual use of the repo is required.** Passing tests are necessary but not
+   sufficient. You must confirm the feature works by actually running the CLI.

--- a/docs/PACKAGE_SPEC.md
+++ b/docs/PACKAGE_SPEC.md
@@ -49,7 +49,7 @@
 		"typescript-eslint": "8.25.0",
 		"vitest": "3.0.7",
 	},
-	"files": ["dist/", "bin/", "skills/", "README.md", "LICENSE"],
+	"files": ["dist/", "bin/", "skills/", "README.md", "LICENSE", "THIRD_PARTY_LICENSES"],
 	"license": "MIT",
 	"repository": {
 		"type": "git",

--- a/docs/PACKAGE_SPEC.md
+++ b/docs/PACKAGE_SPEC.md
@@ -17,6 +17,7 @@
 		"build": "npm run build:iife && npm run build:ts",
 		"build:iife": "node esbuild.config.js",
 		"build:ts": "tsc",
+		"pretest": "npm run build:iife",
 		"test": "vitest run",
 		"test:watch": "vitest --watch",
 		"test:unit": "vitest run tests/unit/",
@@ -33,6 +34,7 @@
 		"cypress": ">=12.0.0",
 	},
 	"dependencies": {
+		"@cypress/unique-selector": "2.1.3",
 		"minimist": "1.2.8",
 		"zod": "3.24.2",
 	},
@@ -47,7 +49,7 @@
 		"typescript-eslint": "8.25.0",
 		"vitest": "3.0.7",
 	},
-	"files": ["dist/", "README.md", "LICENSE"],
+	"files": ["dist/", "bin/", "skills/", "README.md", "LICENSE"],
 	"license": "MIT",
 	"repository": {
 		"type": "git",
@@ -58,24 +60,25 @@
 
 ### Dependency Rationale
 
-| Dependency       | Why                                                                        | Size  |
-| ---------------- | -------------------------------------------------------------------------- | ----- |
-| `minimist`       | CLI argument parsing. Tiny (~400 lines, 0 deps). Same as Playwright.       | ~14KB |
-| `zod`            | Command schema validation. Typed validation that doubles as documentation. | ~56KB |
-| `cypress` (peer) | Must be installed in the consumer's project. We don't bundle it.           | —     |
+| Dependency                 | Why                                                                        | Size  |
+| -------------------------- | -------------------------------------------------------------------------- | ----- |
+| `@cypress/unique-selector` | Generates stable CSS selectors with Cypress priority order.                | ~20KB |
+| `minimist`                 | CLI argument parsing. Tiny (~400 lines, 0 deps). Same as Playwright.       | ~14KB |
+| `zod`                      | Command schema validation. Typed validation that doubles as documentation. | ~56KB |
+| `cypress` (peer)           | Must be installed in the consumer's project. We don't bundle it.           | —     |
 
 ### Dev Dependency Rationale
 
-| Dependency        | Why                                                        |
-| ----------------- | ---------------------------------------------------------- |
-| `esbuild`         | Bundles injected/ into IIFE. Fast, no native binaries.     |
-| `typescript`      | Type checking and ESM compilation.                         |
-| `vitest`          | Test runner. ESM-native, fast.                             |
-| `happy-dom`       | Lightweight DOM implementation for injected/ unit tests.   |
-| `eslint`          | Linting.                                                   |
+| Dependency          | Why                                                      |
+| ------------------- | -------------------------------------------------------- |
+| `esbuild`           | Bundles injected/ into IIFE. Fast, no native binaries.   |
+| `typescript`        | Type checking and ESM compilation.                       |
+| `vitest`            | Test runner. ESM-native, fast.                           |
+| `happy-dom`         | Lightweight DOM implementation for injected/ unit tests. |
+| `eslint`            | Linting.                                                 |
 | `typescript-eslint` | TypeScript support for ESLint 9 flat config.             |
-| `@types/node`     | Node.js type definitions.                                  |
-| `@types/minimist` | minimist type definitions.                                 |
+| `@types/node`       | Node.js type definitions.                                |
+| `@types/minimist`   | minimist type definitions.                               |
 
 ## tsconfig.json
 
@@ -226,7 +229,10 @@ export default tseslint.config(
 	{
 		files: ['**/*.ts'],
 		rules: {
-			'@typescript-eslint/no-unused-vars': ['warn', { argsIgnorePattern: '^_' }],
+			'@typescript-eslint/no-unused-vars': [
+				'warn',
+				{ argsIgnorePattern: '^_' },
+			],
 			'@typescript-eslint/no-explicit-any': 'warn',
 		},
 	},
@@ -247,7 +253,14 @@ export default tseslint.config(
 		rules: {
 			'@typescript-eslint/no-explicit-any': 'off',
 			'@typescript-eslint/ban-ts-comment': 'off',
-			'@typescript-eslint/no-unused-vars': ['warn', { argsIgnorePattern: '^_', varsIgnorePattern: '^_', caughtErrorsIgnorePattern: '^_|^e$' }],
+			'@typescript-eslint/no-unused-vars': [
+				'warn',
+				{
+					argsIgnorePattern: '^_',
+					varsIgnorePattern: '^_',
+					caughtErrorsIgnorePattern: '^_|^e$',
+				},
+			],
 			'no-empty': 'off',
 			'no-control-regex': 'off',
 			'no-case-declarations': 'off',

--- a/docs/READINESS_ASSESSMENT.md
+++ b/docs/READINESS_ASSESSMENT.md
@@ -1,27 +1,27 @@
 # Readiness Assessment for User Testing
 
-> Generated 2026-03-07 against `main` branch.
+> Last updated 2026-04-10 against `main` branch.
 
 ## Build & CI Health
 
-| Check                         | Status           | Notes                                                |
-| ----------------------------- | ---------------- | ---------------------------------------------------- |
-| TypeScript (`tsc --noEmit`)   | **Pass**         | Zero errors                                          |
-| ESLint (`eslint src/ tests/`) | **Pass**         | 0 errors, 10 warnings (all unused-var / `any` style) |
-| Build (`npm run build`)       | **Pass**         | IIFE bundle + TypeScript compile cleanly             |
-| Unit + integration tests      | **634 pass**     | All green                                            |
-| E2E tests                     | **29 pass**      | All green (real Cypress + Electron)                  |
-| Node version                  | **Requires ≥18** | Default nvm is v16 — no `.nvmrc` exists yet          |
+| Check                         | Status           | Notes                                    |
+| ----------------------------- | ---------------- | ---------------------------------------- |
+| TypeScript (`tsc --noEmit`)   | **Pass**         | Zero errors                              |
+| ESLint (`eslint src/ tests/`) | **Pass**         | 0 errors, 0 warnings                     |
+| Build (`npm run build`)       | **Pass**         | IIFE bundle + TypeScript compile cleanly |
+| Vitest suite                  | **1012 pass**    | All green (52 test files)                |
+| Node version                  | **Requires ≥18** | `.nvmrc` with content `18` exists        |
 
 ## Implementation Completeness
 
-All 43 commands specified in `docs/COMMANDS.md` are fully implemented end-to-end.
+All 65 public commands are fully implemented end-to-end. `src/client/commands.ts`
+is the authoritative inventory for the public CLI surface.
 
 ### Module Status
 
 | Module            | Status       | Summary                                                                                                                 |
 | ----------------- | ------------ | ----------------------------------------------------------------------------------------------------------------------- |
-| `src/client/`     | **Complete** | CLI parsing (minimist + zod), 43 validated commands, REPL mode, Unix socket client, session discovery                   |
+| `src/client/`     | **Complete** | CLI parsing (minimist + zod), 65 validated commands, public REPL mode, Unix socket client, session discovery            |
 | `src/daemon/`     | **Complete** | Unix socket server, FIFO command queue, session lifecycle state machine, persistence to `$XDG_STATE_HOME`, idle timeout |
 | `src/cypress/`    | **Complete** | Module API launcher, `cy.task()` bridge, driver spec REPL loop, cross-process IPC via QueueBridge                       |
 | `src/browser/`    | **Complete** | Element ref map, selector generation (`@cypress/unique-selector` with Cypress priority order), IIFE snapshot injection  |
@@ -29,20 +29,25 @@ All 43 commands specified in `docs/COMMANDS.md` are fully implemented end-to-end
 | `src/injected/`   | **Complete** | Ported Playwright aria snapshot (Apache 2.0), YAML tree generation, incremental diffing, element map                    |
 | `bin/cypress-cli` | **Complete** | Executable shim (`#!/usr/bin/env node`)                                                                                 |
 
-### Command Coverage (43/43)
+### Command Coverage (65/65)
 
-| Category    | Count | Commands                                                                                                               |
-| ----------- | ----- | ---------------------------------------------------------------------------------------------------------------------- |
-| Core        | 5     | `open`, `stop`, `status`, `install`, `snapshot`                                                                        |
-| Navigation  | 4     | `navigate`, `back`, `forward`, `reload`                                                                                |
-| Interaction | 12    | `click`, `dblclick`, `rightclick`, `type`, `clear`, `check`, `uncheck`, `select`, `focus`, `blur`, `scrollto`, `hover` |
-| Keyboard    | 1     | `press`                                                                                                                |
-| Assertion   | 3     | `assert`, `asserturl`, `asserttitle`                                                                                   |
-| Execution   | 1     | `run-code`                                                                                                             |
-| Wait        | 2     | `wait`, `waitfor`                                                                                                      |
-| Network     | 5     | `intercept`, `waitforresponse`, `unintercept`, `intercept-list`, `network`                                             |
-| Export      | 3     | `export`, `history`, `undo`                                                                                            |
-| Session     | 7     | `cookie-list`, `cookie-get`, `cookie-set`, `cookie-delete`, `cookie-clear`, `storage-state`, `set-storage-state`       |
+| Category       | Count | Commands                                                                                                                       |
+| -------------- | ----- | ------------------------------------------------------------------------------------------------------------------------------ |
+| Core           | 6     | `open`, `repl`, `stop`, `status`, `install`, `snapshot`                                                                        |
+| Navigation     | 4     | `navigate`, `back`, `forward`, `reload`                                                                                        |
+| Interaction    | 13    | `click`, `dblclick`, `rightclick`, `type`, `clear`, `check`, `uncheck`, `select`, `focus`, `blur`, `scrollto`, `hover`, `fill` |
+| Keyboard       | 1     | `press`                                                                                                                        |
+| Assertion      | 3     | `assert`, `asserturl`, `asserttitle`                                                                                           |
+| Execution      | 4     | `run-code`, `eval`, `cyrun`, `run`                                                                                             |
+| Wait           | 2     | `wait`, `waitfor`                                                                                                              |
+| Network        | 5     | `intercept`, `waitforresponse`, `unintercept`, `intercept-list`, `network`                                                     |
+| Cookies        | 5     | `cookie-list`, `cookie-get`, `cookie-set`, `cookie-delete`, `cookie-clear`                                                     |
+| State          | 2     | `state-save`, `state-load`                                                                                                     |
+| localStorage   | 5     | `localstorage-list`, `localstorage-get`, `localstorage-set`, `localstorage-delete`, `localstorage-clear`                       |
+| sessionStorage | 5     | `sessionstorage-list`, `sessionstorage-get`, `sessionstorage-set`, `sessionstorage-delete`, `sessionstorage-clear`             |
+| DevTools       | 2     | `console`, `screenshot`                                                                                                        |
+| Page           | 5     | `drag`, `upload`, `dialog-accept`, `dialog-dismiss`, `resize`                                                                  |
+| Export         | 3     | `export`, `history`, `undo`                                                                                                    |
 
 ## What's Ready for User Testing
 
@@ -64,38 +69,44 @@ The full happy path works end-to-end:
 
 ## Items to Address Before / During User Testing
 
-### Must-fix
+### ~~Must-fix~~ (Resolved)
 
-1. **Add `.nvmrc` file** — The project requires Node ≥18, but the default nvm version is 16. Without `.nvmrc`, anyone running `npm install` or `npx vitest` on the default Node will hit `crypto.getRandomValues is not a function` (Vite/Vitest) and `structuredClone is not defined` (ESLint).
+1. ~~**Add `.nvmrc` file**~~ — ✅ `.nvmrc` with content `18` now exists.
 
-2. **E2E tests require `npm run build:iife` first** — The E2E helpers fail fast when `dist/injected.iife.js` is missing, printing an error that instructs running `npm run build:iife` before the suite. This command produces both the injected IIFE (`dist/injected.iife.js`) and the driver spec bundle (`dist/cypress/driverSpec.js`). Running `npx vitest run` without building first causes 6 E2E test failures. Consider adding a `pretest` script or documenting the requirement.
+2. ~~**E2E tests require `npm run build:iife` first**~~ — ✅ `pretest` script added to `package.json`.
 
-### Should-fix
+### ~~Should-fix~~ (Resolved)
 
-3. **ESLint warnings (10)** — All are minor:
-   - 3 unused variables (`_success`, `_positional` ×2)
-   - 2 `any` types in test files
-   - 3 unused imports in test files
-   - 2 unused definitions in test utilities
+3. ~~**ESLint warnings (10)**~~ — ✅ All resolved. Lint now passes with 0 warnings.
 
-4. **README quickstart** — Users need clear install + usage instructions. At minimum: prerequisites (Node ≥18, Cypress ≥12), install steps, and a basic workflow example.
+4. ~~**README quickstart**~~ — ✅ README has complete install + usage instructions.
 
-5. **Verify `npm link` / local install** — The `bin` field points to `./dist/client/main.js`. Worth confirming `npm link` and `npx .` work for local testing before distributing.
+5. ~~**Verify `npm link` / local install**~~ — ✅ `bin` field points correctly to `./dist/client/main.js`.
 
-### Nice-to-have
+### ~~Nice-to-have~~ (Resolved)
 
-6. **`tsconfig-paths` warnings** — E2E runs print "Couldn't find tsconfig.json. tsconfig-paths will be skipped" (6 times). Cosmetic but noisy.
+6. ~~**Pretest build step**~~ — ✅ `"pretest": "npm run build:iife"` added to `package.json`.
 
-7. **Pretest build step** — Add `"pretest": "npm run build:iife"` to `package.json` so `npm test` works without a separate build step.
+### Known Non-Blocking Warning Noise
+
+7. **`tsconfig-paths` warnings** — Still appear during Cypress-backed `npx vitest run` slices as `Couldn't find tsconfig.json. tsconfig-paths will be skipped`. They are non-fatal, do not affect test results, and are not blocking 1.0.
+
+8. **`MaxListenersExceededWarning`** — Still appears intermittently during navigation e2e coverage. It is non-fatal, does not fail the suite, and is not blocking 1.0.
 
 ## Test Summary
 
 ```
-Total:  663 tests (634 unit/integration + 29 E2E)
-Pass:   663
+Total:  1009 tests (52 test files)
+Total:  1012 tests (52 test files)
+Pass:   1012
 Fail:   0
 ```
 
 ## Bottom Line
 
-**The application is functionally complete and ready for user testing.** All specified commands are implemented, the full data flow (CLI → daemon → Cypress → browser → back) works end-to-end, and all 663 tests pass. The remaining gaps are operational (Node version pinning, docs, packaging) rather than functional.
+**The application is functionally complete and ready for release.** All 65 public
+commands are implemented, including the public `repl` command, the full data flow
+(CLI → daemon → Cypress → browser → back) works end-to-end, and all 1012 tests pass.
+The remaining baseline warning noise (`tsconfig-paths` skipped messages and an
+intermittent `MaxListenersExceededWarning`) is still present, but it is non-fatal and
+not blocking 1.0.

--- a/docs/READINESS_ASSESSMENT.md
+++ b/docs/READINESS_ASSESSMENT.md
@@ -96,7 +96,6 @@ The full happy path works end-to-end:
 ## Test Summary
 
 ```
-Total:  1009 tests (52 test files)
 Total:  1012 tests (52 test files)
 Pass:   1012
 Fail:   0

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -50,34 +50,34 @@ validation activity rather than a code change.
 
 ## P1 — Core Command Parity
 
-| #   | Issue                                                                                                 | Labels      | Cypress API                              |
-| --- | ----------------------------------------------------------------------------------------------------- | ----------- | ---------------------------------------- |
-| #48 | [eval command](https://github.com/kylehgc/cypress-cli/issues/48)                                      | P1, command | `cy.window().then(win => win.eval(...))` |
-| #49 | [fill command](https://github.com/kylehgc/cypress-cli/issues/49)                                      | P1, command | `cy.get(sel).clear().type(text)`         |
-| #50 | [dialog-accept / dialog-dismiss](https://github.com/kylehgc/cypress-cli/issues/50)                    | P1, command | `cy.on('window:confirm', ...)`           |
-| #51 | [resize command](https://github.com/kylehgc/cypress-cli/issues/51)                                    | P1, command | `cy.viewport(w, h)`                      |
-| #52 | [screenshot command](https://github.com/kylehgc/cypress-cli/issues/52)                                | P1, command | `cy.screenshot()`                        |
-| #53 | [drag command](https://github.com/kylehgc/cypress-cli/issues/53)                                      | P1, command | trigger chain or plugin                  |
-| #54 | [upload command](https://github.com/kylehgc/cypress-cli/issues/54)                                    | P1, command | `cy.get(sel).selectFile(path)`           |
-| #55 | [Command aliases: close, goto, go-back, go-forward](https://github.com/kylehgc/cypress-cli/issues/55) | P1, command | Aliases for existing commands            |
+| #   | Issue                                                                                                 | Labels      | Cypress API                                 |
+| --- | ----------------------------------------------------------------------------------------------------- | ----------- | ------------------------------------------- |
+| #48 | [eval command](https://github.com/kylehgc/cypress-cli/issues/48)                                      | P1, command | ✅ `cy.window().then(win => win.eval(...))` |
+| #49 | [fill command](https://github.com/kylehgc/cypress-cli/issues/49)                                      | P1, command | ✅ `cy.get(sel).clear().type(text)`         |
+| #50 | [dialog-accept / dialog-dismiss](https://github.com/kylehgc/cypress-cli/issues/50)                    | P1, command | ✅ `cy.on('window:confirm', ...)`           |
+| #51 | [resize command](https://github.com/kylehgc/cypress-cli/issues/51)                                    | P1, command | ✅ `cy.viewport(w, h)`                      |
+| #52 | [screenshot command](https://github.com/kylehgc/cypress-cli/issues/52)                                | P1, command | ✅ `cy.screenshot()`                        |
+| #53 | [drag command](https://github.com/kylehgc/cypress-cli/issues/53)                                      | P1, command | ✅ trigger chain or plugin                  |
+| #54 | [upload command](https://github.com/kylehgc/cypress-cli/issues/54)                                    | P1, command | ✅ `cy.get(sel).selectFile(path)`           |
+| #55 | [Command aliases: close, goto, go-back, go-forward](https://github.com/kylehgc/cypress-cli/issues/55) | P1, command | ✅ Aliases for existing commands            |
 
 | #73 | [Long-running real-world validation](https://github.com/kylehgc/cypress-cli/issues/73) | P1, testing | Side-by-side comparison with playwright-cli |
 | #80 | [Ref counter grows unboundedly in long sessions](https://github.com/kylehgc/cypress-cli/issues/80) | P1, bug | ✅ Reset ref counter per snapshot (PR #87) |
 
-P1 issues can be worked in parallel once P0 foundation is in place.
+P1 issues are all complete except #73 (long-running validation).
 
 ## P2 — DevTools & Storage
 
-| #   | Issue                                                                                      | Labels      | Cypress API                                     |
-| --- | ------------------------------------------------------------------------------------------ | ----------- | ----------------------------------------------- |
-| #56 | [Cookie management commands](https://github.com/kylehgc/cypress-cli/issues/56)             | P2, command | `cy.getCookie()`, `cy.setCookie()`, etc.        |
-| #57 | [localStorage / sessionStorage commands](https://github.com/kylehgc/cypress-cli/issues/57) | P2, command | `cy.window().then(win => win.localStorage.*)`   |
-| #58 | [console command](https://github.com/kylehgc/cypress-cli/issues/58)                        | P2, command | `Cypress.on('window:before:load', ...)`         |
-| #59 | [Network monitoring and route mocking](https://github.com/kylehgc/cypress-cli/issues/59)   | P2, command | `cy.intercept()`                                |
-| #60 | [state-save / state-load commands](https://github.com/kylehgc/cypress-cli/issues/60)       | P2, command | Cookies + localStorage serialization            |
+| #   | Issue                                                                                      | Labels      | Cypress API                                          |
+| --- | ------------------------------------------------------------------------------------------ | ----------- | ---------------------------------------------------- |
+| #56 | [Cookie management commands](https://github.com/kylehgc/cypress-cli/issues/56)             | P2, command | ✅ `cy.getCookie()`, `cy.setCookie()`, etc.          |
+| #57 | [localStorage / sessionStorage commands](https://github.com/kylehgc/cypress-cli/issues/57) | P2, command | ✅ `cy.window().then(win => win.localStorage.*)`     |
+| #58 | [console command](https://github.com/kylehgc/cypress-cli/issues/58)                        | P2, command | ✅ `Cypress.on('window:before:load', ...)`           |
+| #59 | [Network monitoring and route mocking](https://github.com/kylehgc/cypress-cli/issues/59)   | P2, command | ✅ `cy.intercept()`                                  |
+| #60 | [state-save / state-load commands](https://github.com/kylehgc/cypress-cli/issues/60)       | P2, command | ✅ Cookies + localStorage serialization              |
 | #61 | [run-code command](https://github.com/kylehgc/cypress-cli/issues/61)                       | P2, command | ✅ `cy.window().then(win => win.eval(...))` (PR #93) |
-| #77 | [cyrun command](https://github.com/kylehgc/cypress-cli/issues/77)                          | P2, command | Execute arbitrary Cypress chains                |
-| #81 | [run command](https://github.com/kylehgc/cypress-cli/issues/81)                            | P2, command | Execute generated test files and report results |
+| #77 | [cyrun command](https://github.com/kylehgc/cypress-cli/issues/77)                          | P2, command | ✅ Execute arbitrary Cypress chains                  |
+| #81 | [run command](https://github.com/kylehgc/cypress-cli/issues/81)                            | P2, command | ✅ Execute generated test files and report results   |
 
 ## P3 — Advanced
 
@@ -106,24 +106,30 @@ These are architectural constraints of Cypress that cannot be worked around:
 
 ## Comparison: Current Command Set
 
-### Implemented (29 commands)
+### Implemented (65 commands, 69 registry entries with aliases)
 
-| Category    | Commands                                                                                                               |
-| ----------- | ---------------------------------------------------------------------------------------------------------------------- |
-| Core        | `open`, `stop`, `status`, `snapshot`                                                                                   |
-| Navigation  | `navigate`, `back`, `forward`, `reload`                                                                                |
-| Interaction | `click`, `dblclick`, `rightclick`, `type`, `clear`, `check`, `uncheck`, `select`, `focus`, `blur`, `scrollto`, `hover` |
-| Keyboard    | `press`                                                                                                                |
-| Assertion   | `assert`, `asserturl`, `asserttitle`                                                                                   |
-| Execution   | `run-code`                                                                                                             |
-| Export      | `export`, `history`, `undo`                                                                                            |
-| Wait        | `wait`, `waitfor`                                                                                                      |
+| Category       | Commands                                                                                                                       |
+| -------------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| Core           | `open`, `repl`, `stop`, `status`, `install`, `snapshot`                                                                        |
+| Navigation     | `navigate`, `back`, `forward`, `reload`                                                                                        |
+| Interaction    | `click`, `dblclick`, `rightclick`, `type`, `clear`, `check`, `uncheck`, `select`, `focus`, `blur`, `scrollto`, `hover`, `fill` |
+| Keyboard       | `press`                                                                                                                        |
+| Assertion      | `assert`, `asserturl`, `asserttitle`                                                                                           |
+| Execution      | `run-code`, `eval`, `cyrun`, `run`                                                                                             |
+| Export         | `export`, `history`, `undo`                                                                                                    |
+| Wait           | `wait`, `waitfor`                                                                                                              |
+| Network        | `intercept`, `waitforresponse`, `unintercept`, `intercept-list`, `network`                                                     |
+| Cookies        | `cookie-list`, `cookie-get`, `cookie-set`, `cookie-delete`, `cookie-clear`                                                     |
+| State          | `state-save`, `state-load`                                                                                                     |
+| localStorage   | `localstorage-list`, `localstorage-get`, `localstorage-set`, `localstorage-delete`, `localstorage-clear`                       |
+| sessionStorage | `sessionstorage-list`, `sessionstorage-get`, `sessionstorage-set`, `sessionstorage-delete`, `sessionstorage-clear`             |
+| DevTools       | `console`, `screenshot`                                                                                                        |
+| Page           | `drag`, `upload`, `dialog-accept`, `dialog-dismiss`, `resize`                                                                  |
+| Aliases        | `close` → `stop`, `goto` → `navigate`, `go-back` → `back`, `go-forward` → `forward`                                            |
 
-### Planned (from issues above)
+### Not Planned (P3 / Infeasible)
 
-`eval`, `fill`, `drag`, `upload`, `screenshot`, `resize`, `dialog-accept`,
-`dialog-dismiss`, `close` (alias), `goto` (alias), `go-back` (alias),
-`go-forward` (alias), `cookie-*` (5), `localstorage-*` (5),
-`sessionstorage-*` (5), `console`, `network`, `route`, `route-list`,
-`unroute`, `state-save`, `state-load`, `delete-data`,
-`keydown`, `keyup`, `mousemove`, `mousedown`, `mouseup`, `mousewheel`
+The following are tracked in open issues but not prioritized for initial release:
+
+- `keydown`, `keyup`, `mousemove`, `mousedown`, `mouseup`, `mousewheel` — P3, synthetic events only (#62)
+- `delete-data`, browser config on open — P3 (#63)

--- a/package.json
+++ b/package.json
@@ -48,7 +48,8 @@
 		"bin/",
 		"skills/",
 		"README.md",
-		"LICENSE"
+		"LICENSE",
+		"THIRD_PARTY_LICENSES"
 	],
 	"license": "MIT",
 	"repository": {

--- a/skills/cypress-cli/SKILL.md
+++ b/skills/cypress-cli/SKILL.md
@@ -9,77 +9,174 @@ user-invocable: true
 ## What this skill does
 
 This skill teaches you how to use the `cypress-cli` tool to interact with live
-web pages through real Cypress commands. It is the primary way to browse,
-inspect, and test web pages in this project.
+web pages through real Cypress commands. Use it to open pages, inspect aria
+snapshots, interact with elements, inspect browser state, export Cypress tests,
+and run targeted browser or Cypress code.
 
 ## When to use this skill
 
 - When you need to open a web page and inspect its DOM
 - When you need to interact with elements (click, type, check, select, etc.)
 - When you need to assert element state
+- When you need cookies, localStorage, sessionStorage, or saved browser state
+- When you need network inspection or request mocking
+- When you need browser console output or screenshots
 - When you need to generate Cypress test code from a session
-- When you need to execute arbitrary Cypress code against a live page
+- When you need to execute browser-side JavaScript or Cypress chain code
 
-## Commands
+## Output format
 
-| Command           | Example                                        |
-| ----------------- | ---------------------------------------------- |
-| `open`            | `cypress-cli open https://example.com`         |
-| `snapshot`        | `cypress-cli snapshot`                         |
-| `click`           | `cypress-cli click e5`                         |
-| `type`            | `cypress-cli type e12 'hello'`                 |
-| `fill`            | `cypress-cli fill e12 'full replacement text'` |
-| `clear`           | `cypress-cli clear e12`                        |
-| `check`           | `cypress-cli check e8`                         |
-| `uncheck`         | `cypress-cli uncheck e8`                       |
-| `select`          | `cypress-cli select e15 'Option A'`            |
-| `scrollto`        | `cypress-cli scrollto e3`                      |
-| `hover`           | `cypress-cli hover e7`                         |
-| `focus`           | `cypress-cli focus e12`                        |
-| `blur`            | `cypress-cli blur e12`                         |
-| `press`           | `cypress-cli press Enter`                      |
-| `dblclick`        | `cypress-cli dblclick e5`                      |
-| `rightclick`      | `cypress-cli rightclick e5`                    |
-| `navigate`        | `cypress-cli navigate https://other.com`       |
-| `back`            | `cypress-cli back`                             |
-| `forward`         | `cypress-cli forward`                          |
-| `reload`          | `cypress-cli reload`                           |
-| `assert`          | `cypress-cli assert e5 have.text 'Submit'`     |
-| `asserturl`       | `cypress-cli asserturl include '/dashboard'`   |
-| `asserttitle`     | `cypress-cli asserttitle eq 'Home'`            |
-| `wait`            | `cypress-cli wait 1000`                        |
-| `waitfor`         | `cypress-cli waitfor e12`                      |
-| `intercept`       | `cypress-cli intercept '**/api/users'`         |
-| `waitforresponse` | `cypress-cli waitforresponse '**/api/users'`   |
-| `unintercept`     | `cypress-cli unintercept '**/api/users'`       |
-| `intercept-list`  | `cypress-cli intercept-list`                   |
-| `network`         | `cypress-cli network`                          |
-| `screenshot`      | `cypress-cli screenshot`                       |
-| `drag`            | `cypress-cli drag e3 e7`                       |
-| `upload`          | `cypress-cli upload e10 ./file.pdf`            |
-| `dialog-accept`   | `cypress-cli dialog-accept`                    |
-| `dialog-dismiss`  | `cypress-cli dialog-dismiss`                   |
-| `resize`          | `cypress-cli resize 1280 720`                  |
-| `run-code`        | `cypress-cli run-code "document.title"`        |
-| `export`          | `cypress-cli export`                           |
-| `history`         | `cypress-cli history`                          |
-| `undo`            | `cypress-cli undo`                             |
-| `stop`            | `cypress-cli stop`                             |
-
-## How to read snapshots
-
-Every command returns output in this format:
+Most page-oriented commands return output like this:
 
 ```text
 ### Page
 - Page URL: https://example.com
-- Page Title: Example Page
+- Page Title: Example
 ### Snapshot
-Snapshot → .cypress-cli/page-YYYY-MM-DDTHH-MM-SS-mmmZ.yml
+[Snapshot](.cypress-cli/page-2026-04-10T19-22-42-679Z.yml)
 ```
 
-The `### Snapshot` section contains a markdown-formatted link to the YAML
-snapshot file on disk (e.g., `.cypress-cli/page-<timestamp>.yml`).
+Structured-data commands such as `console`, `network`, `history`, storage
+commands, and `run` return JSON-like data or summaries instead of a snapshot.
+
+## Commands
+
+### Core
+
+| Command    | Example                                | Purpose                                                     |
+| ---------- | -------------------------------------- | ----------------------------------------------------------- |
+| `open`     | `cypress-cli open https://example.com` | Start or reuse a session and navigate to a URL              |
+| `repl`     | `cypress-cli repl`                     | Start interactive REPL mode for an existing session         |
+| `snapshot` | `cypress-cli snapshot`                 | Capture the current aria snapshot                           |
+| `status`   | `cypress-cli status`                   | Show session status and metadata                            |
+| `install`  | `cypress-cli install --skills`         | Install the bundled skill into `.github/skills/cypress-cli` |
+| `stop`     | `cypress-cli stop`                     | Stop the active session                                     |
+
+### Navigation
+
+| Command    | Example                                              | Purpose                                |
+| ---------- | ---------------------------------------------------- | -------------------------------------- |
+| `navigate` | `cypress-cli navigate https://example.com/dashboard` | Visit a new URL in the current session |
+| `back`     | `cypress-cli back`                                   | Go back in browser history             |
+| `forward`  | `cypress-cli forward`                                | Go forward in browser history          |
+| `reload`   | `cypress-cli reload`                                 | Reload the current page                |
+
+### Interaction
+
+| Command          | Example                                        | Purpose                                             |
+| ---------------- | ---------------------------------------------- | --------------------------------------------------- |
+| `click`          | `cypress-cli click e5`                         | Click an element by ref                             |
+| `dblclick`       | `cypress-cli dblclick e5`                      | Double-click an element by ref                      |
+| `rightclick`     | `cypress-cli rightclick e5`                    | Right-click an element by ref                       |
+| `type`           | `cypress-cli type e12 'hello'`                 | Type text into an element                           |
+| `fill`           | `cypress-cli fill e12 'full replacement text'` | Clear and replace text in an element                |
+| `clear`          | `cypress-cli clear e12`                        | Clear an input element                              |
+| `check`          | `cypress-cli check e8`                         | Check a checkbox or radio input                     |
+| `uncheck`        | `cypress-cli uncheck e8`                       | Uncheck a checkbox                                  |
+| `select`         | `cypress-cli select e15 'Option A'`            | Select an option from a `<select>`                  |
+| `focus`          | `cypress-cli focus e12`                        | Focus an element                                    |
+| `blur`           | `cypress-cli blur e12`                         | Blur an element                                     |
+| `scrollto`       | `cypress-cli scrollto e3`                      | Scroll an element into view or scroll to a position |
+| `hover`          | `cypress-cli hover e7`                         | Trigger hover on an element                         |
+| `drag`           | `cypress-cli drag e3 e7`                       | Drag one element onto another                       |
+| `upload`         | `cypress-cli upload e10 ./file.pdf`            | Upload a file through a file input                  |
+| `dialog-accept`  | `cypress-cli dialog-accept`                    | Accept the next browser dialog                      |
+| `dialog-dismiss` | `cypress-cli dialog-dismiss`                   | Dismiss the next browser dialog                     |
+| `resize`         | `cypress-cli resize 1280 720`                  | Change the browser viewport size                    |
+
+### Keyboard
+
+| Command | Example                   | Purpose                         |
+| ------- | ------------------------- | ------------------------------- |
+| `press` | `cypress-cli press Enter` | Send a keyboard key to the page |
+
+### Assertion
+
+| Command       | Example                                      | Purpose                   |
+| ------------- | -------------------------------------------- | ------------------------- |
+| `assert`      | `cypress-cli assert e5 have.text 'Submit'`   | Assert on an element      |
+| `asserturl`   | `cypress-cli asserturl include '/dashboard'` | Assert on the current URL |
+| `asserttitle` | `cypress-cli asserttitle eq 'Home'`          | Assert on the page title  |
+
+### Wait
+
+| Command   | Example                   | Purpose                             |
+| --------- | ------------------------- | ----------------------------------- |
+| `wait`    | `cypress-cli wait 1000`   | Wait a fixed number of milliseconds |
+| `waitfor` | `cypress-cli waitfor e12` | Wait for an element to exist        |
+
+### Execution
+
+| Command    | Example                                                            | Purpose                                                           |
+| ---------- | ------------------------------------------------------------------ | ----------------------------------------------------------------- |
+| `run-code` | `cypress-cli run-code "document.querySelectorAll('input').length"` | Execute browser-side JavaScript in the page context               |
+| `eval`     | `cypress-cli eval "document.title"`                                | Evaluate a JavaScript expression on the page or on a specific ref |
+| `cyrun`    | `cypress-cli cyrun "cy.url().then(u => u)"`                        | Execute Cypress chain code in the Cypress runner context          |
+| `run`      | `cypress-cli run ./generated.cy.ts`                                | Run a Cypress spec file and report structured results             |
+
+### Export and history
+
+| Command   | Example                                       | Purpose                                       |
+| --------- | --------------------------------------------- | --------------------------------------------- |
+| `export`  | `cypress-cli export --file ./generated.cy.ts` | Export session history as a Cypress test file |
+| `history` | `cypress-cli history`                         | Show commands recorded for export             |
+| `undo`    | `cypress-cli undo`                            | Remove the last command from export history   |
+
+### Network
+
+| Command           | Example                                                                   | Purpose                                       |
+| ----------------- | ------------------------------------------------------------------------- | --------------------------------------------- |
+| `intercept`       | `cypress-cli intercept '**/api/users' --status 200 --body '{"users":[]}'` | Register a request intercept or mock response |
+| `waitforresponse` | `cypress-cli waitforresponse '**/api/users'`                              | Wait for a previously intercepted response    |
+| `unintercept`     | `cypress-cli unintercept '**/api/users'`                                  | Remove one intercept or all intercepts        |
+| `intercept-list`  | `cypress-cli intercept-list`                                              | List active intercepts                        |
+| `network`         | `cypress-cli network`                                                     | Show captured network requests                |
+
+### Cookies
+
+| Command         | Example                                | Purpose                 |
+| --------------- | -------------------------------------- | ----------------------- |
+| `cookie-list`   | `cypress-cli cookie-list`              | List cookies            |
+| `cookie-get`    | `cypress-cli cookie-get session_id`    | Read a cookie by name   |
+| `cookie-set`    | `cypress-cli cookie-set theme dark`    | Set a cookie            |
+| `cookie-delete` | `cypress-cli cookie-delete session_id` | Delete a cookie by name |
+| `cookie-clear`  | `cypress-cli cookie-clear`             | Clear all cookies       |
+
+### localStorage
+
+| Command               | Example                                     | Purpose                           |
+| --------------------- | ------------------------------------------- | --------------------------------- |
+| `localstorage-list`   | `cypress-cli localstorage-list`             | List all localStorage entries     |
+| `localstorage-get`    | `cypress-cli localstorage-get token`        | Read a localStorage value by key  |
+| `localstorage-set`    | `cypress-cli localstorage-set token abc123` | Set a localStorage key/value pair |
+| `localstorage-delete` | `cypress-cli localstorage-delete token`     | Delete a localStorage key         |
+| `localstorage-clear`  | `cypress-cli localstorage-clear`            | Clear all localStorage entries    |
+
+### sessionStorage
+
+| Command                 | Example                                      | Purpose                             |
+| ----------------------- | -------------------------------------------- | ----------------------------------- |
+| `sessionstorage-list`   | `cypress-cli sessionstorage-list`            | List all sessionStorage entries     |
+| `sessionstorage-get`    | `cypress-cli sessionstorage-get draft`       | Read a sessionStorage value by key  |
+| `sessionstorage-set`    | `cypress-cli sessionstorage-set draft hello` | Set a sessionStorage key/value pair |
+| `sessionstorage-delete` | `cypress-cli sessionstorage-delete draft`    | Delete a sessionStorage key         |
+| `sessionstorage-clear`  | `cypress-cli sessionstorage-clear`           | Clear all sessionStorage entries    |
+
+### State
+
+| Command      | Example                                          | Purpose                                                     |
+| ------------ | ------------------------------------------------ | ----------------------------------------------------------- |
+| `state-save` | `cypress-cli state-save .cypress-cli/state.json` | Save cookies, localStorage, and sessionStorage to disk      |
+| `state-load` | `cypress-cli state-load .cypress-cli/state.json` | Restore cookies, localStorage, and sessionStorage from disk |
+
+### Diagnostics and page capture
+
+| Command      | Example                  | Purpose                                  |
+| ------------ | ------------------------ | ---------------------------------------- |
+| `console`    | `cypress-cli console`    | Return captured browser console messages |
+| `screenshot` | `cypress-cli screenshot` | Capture a page or element screenshot     |
+
+## How to read snapshots
 
 The snapshot file (YAML) contains the page's aria tree with element references:
 
@@ -115,13 +212,25 @@ cypress-cli snapshot
 # 5. Assert element state
 cypress-cli assert e3 have.value 'user@test.com'
 
-# 6. Run arbitrary Cypress code
-cypress-cli run-code "cy.get('#modal').should('be.visible')"
+# 6. Run browser-side JavaScript
+cypress-cli run-code "document.querySelectorAll('input').length"
 
-# 7. Export session as a Cypress test file
-cypress-cli export
+# 7. Run Cypress chain code in the runner context
+cypress-cli cyrun "cy.url().then(u => u)"
 
-# 8. Stop the session
+# 8. Use the interactive REPL when you want a prompt
+cypress-cli repl
+# cypress-cli> snapshot
+# cypress-cli> status
+# cypress-cli> exit
+
+# 9. Export session as a Cypress test file
+cypress-cli export --file ./generated.cy.ts
+
+# 10. Run the exported Cypress spec
+cypress-cli run ./generated.cy.ts
+
+# 11. Stop the session
 cypress-cli stop
 ```
 
@@ -130,7 +239,11 @@ cypress-cli stop
 - **Always read the snapshot file** after `open` to discover element refs
 - **Snapshot files accumulate** in `.cypress-cli/` — each command writes a new one
 - Use `--json` flag on any command for machine-readable output
-- The `run-code` command accepts any valid JavaScript expression
+- `run-code` executes browser-side JavaScript via `window.eval(...)`
+- `eval` returns expression results and can optionally evaluate against a specific ref
+- `cyrun` is for Cypress chain code such as `cy.get(...)`, not browser-side JavaScript
+- `run` executes a Cypress spec file and does not require an active browser session
+- `install --skills` copies this source skill to `.github/skills/cypress-cli/`
 - If a command fails, the response includes an error message and a recovery snapshot
 
 ## Waiting after SPA navigation

--- a/src/client/cli.ts
+++ b/src/client/cli.ts
@@ -19,6 +19,7 @@ import { ClientSession, type ClientResult } from './session.js';
 import { ClientConnectionError } from './socketConnection.js';
 import { openSession } from './open.js';
 import { runLocalCommand } from './install.js';
+import { startRepl } from './repl.js';
 import { createClientLogger } from '../shared/logger.js';
 
 /**
@@ -368,6 +369,11 @@ export async function run(argv: string[]): Promise<CliResult> {
 				exitCode: result.success ? EXIT_SUCCESS : EXIT_COMMAND_ERROR,
 				output: formatResult(result, flags.json),
 			};
+		}
+
+		if (parsedCommand.command === 'repl') {
+			await startRepl({ session: flags.session, json: flags.json });
+			return { exitCode: EXIT_SUCCESS, output: '' };
 		}
 
 		const localResult = await runLocalCommand(parsedCommand);

--- a/src/client/commands.ts
+++ b/src/client/commands.ts
@@ -28,6 +28,14 @@ export const open = declareCommand({
 	}),
 });
 
+export const repl = declareCommand({
+	name: 'repl',
+	category: 'core',
+	description: 'Start interactive REPL mode',
+	args: z.object({}),
+	options: z.object({}),
+});
+
 export const stop = declareCommand({
 	name: 'stop',
 	category: 'core',
@@ -467,11 +475,7 @@ export const cyrun = declareCommand({
 	description:
 		'Execute an arbitrary Cypress chain string in the Cypress runner context',
 	args: z.object({
-		code: z
-			.string()
-			.trim()
-			.min(1)
-			.describe('Cypress chain code to execute'),
+		code: z.string().trim().min(1).describe('Cypress chain code to execute'),
 	}),
 	options: z.object({}),
 });
@@ -515,7 +519,9 @@ export const network = declareCommand({
 		clear: z
 			.boolean()
 			.optional()
-			.describe('Clear the network log instead of listing it (returns cleared count)'),
+			.describe(
+				'Clear the network log instead of listing it (returns cleared count)',
+			),
 	}),
 });
 
@@ -584,7 +590,10 @@ export const cookieList = declareCommand({
 	description: 'List browser cookies, optionally filtered by domain',
 	args: z.object({}),
 	options: z.object({
-		domain: z.string().optional().describe('Filter cookies to a specific domain'),
+		domain: z
+			.string()
+			.optional()
+			.describe('Filter cookies to a specific domain'),
 	}),
 });
 
@@ -872,6 +881,7 @@ export const runTest = declareCommand({
  */
 export const allCommands = [
 	open,
+	repl,
 	stop,
 	status,
 	install,
@@ -949,6 +959,7 @@ export function buildRegistry(): ReadonlyMap<string, CommandRegistryEntry> {
 
 	// Core
 	registry.set('open', { schema: open, positionals: ['url'] });
+	registry.set('repl', { schema: repl, positionals: [] });
 	registry.set('stop', { schema: stop, positionals: [] });
 	registry.set('status', { schema: status, positionals: [] });
 	registry.set('install', { schema: install, positionals: [] });

--- a/src/client/open.ts
+++ b/src/client/open.ts
@@ -135,7 +135,9 @@ export async function openSession(
 	if (!requestedResume) {
 		const existingResult = await tryReuseOpenSession(session, parsedCommand);
 		if (existingResult) {
-			return existingResult;
+			return existingResult.success
+				? existingResult
+				: sanitizeFailedOpenResult(existingResult);
 		}
 	}
 
@@ -160,6 +162,13 @@ export async function openSession(
 		dependencies.sleep ?? defaultSleep,
 		dependencies.startupTimeoutMs ?? DEFAULT_STARTUP_TIMEOUT_MS,
 	);
+}
+
+function sanitizeFailedOpenResult(result: ClientResult): ClientResult {
+	return {
+		success: false,
+		...(result.error !== undefined && { error: result.error }),
+	};
 }
 
 async function tryReuseOpenSession(

--- a/src/daemon/daemon.ts
+++ b/src/daemon/daemon.ts
@@ -406,7 +406,7 @@ export class Daemon {
 		}
 
 		if (action === 'run') {
-			void handleRunTest(conn, message);
+			void handleRunTest(conn, message, this._findRunningSession());
 			return;
 		}
 
@@ -483,11 +483,7 @@ export class Daemon {
 
 					// state-save: write evalResult (state JSON) to a file
 					let stateFilePath: string | undefined;
-					if (
-						action === 'state-save' &&
-						result.success &&
-						result.evalResult
-					) {
+					if (action === 'state-save' && result.success && result.evalResult) {
 						const stateFilename =
 							typeof command.options?.['filename'] === 'string'
 								? command.options['filename']
@@ -680,11 +676,9 @@ export class Daemon {
 				const relativeToBase = path.relative(baseDir, filePath);
 				const relativeToCwd = path.relative(process.cwd(), filePath);
 				const withinBase =
-					!relativeToBase.startsWith('..') &&
-					!path.isAbsolute(relativeToBase);
+					!relativeToBase.startsWith('..') && !path.isAbsolute(relativeToBase);
 				const withinCwd =
-					!relativeToCwd.startsWith('..') &&
-					!path.isAbsolute(relativeToCwd);
+					!relativeToCwd.startsWith('..') && !path.isAbsolute(relativeToCwd);
 
 				if (!withinBase && !withinCwd) {
 					continue;
@@ -823,9 +817,12 @@ export class Daemon {
 			});
 		}, this._sessionInactivityTimeout);
 	}
-
 }
 
 export { buildQueuedCommand } from './commandBuilder.js';
-export { resolveSocketDir, isSocketAlive, cleanStaleSockets } from './socketUtils.js';
+export {
+	resolveSocketDir,
+	isSocketAlive,
+	cleanStaleSockets,
+} from './socketUtils.js';
 export { DaemonError } from './errors.js';

--- a/src/daemon/handlers.ts
+++ b/src/daemon/handlers.ts
@@ -1,4 +1,5 @@
 import fs from 'node:fs/promises';
+import os from 'node:os';
 import path from 'node:path';
 
 import { generateTestFile } from '../codegen/codegen.js';
@@ -228,7 +229,11 @@ export function checkInterceptDrift(
 	command: QueuedCommand,
 	result: CommandResult,
 ): void {
-	const DRIFT_TRACKED_ACTIONS = new Set(['network', 'intercept', 'unintercept']);
+	const DRIFT_TRACKED_ACTIONS = new Set([
+		'network',
+		'intercept',
+		'unintercept',
+	]);
 	if (!DRIFT_TRACKED_ACTIONS.has(command.action)) return;
 
 	if (!result.evalResult) return;
@@ -257,6 +262,7 @@ export function checkInterceptDrift(
 export async function handleRunTest(
 	conn: SocketConnection,
 	message: CommandMessage,
+	session?: Session,
 ): Promise<void> {
 	const args = message.params.args;
 	const file = args._[1] as string | undefined;
@@ -272,7 +278,6 @@ export async function handleRunTest(
 
 	const resolvedFile = path.resolve(file);
 
-	// Validate file extension
 	if (!/\.cy\.[tj]s$/.test(resolvedFile)) {
 		sendError(conn, {
 			id: message.id,
@@ -281,7 +286,6 @@ export async function handleRunTest(
 		return;
 	}
 
-	// Validate file exists
 	try {
 		await fs.access(resolvedFile);
 	} catch {
@@ -293,80 +297,145 @@ export async function handleRunTest(
 	}
 
 	try {
-		const cypress = await import('cypress');
-		const result = await cypress.default.run({
-			spec: resolvedFile,
-			browser: (options['browser'] as string) ?? 'electron',
-			headed: options['headed'] === true,
-		} as Record<string, unknown>);
-
-		// Cypress returns CypressFailedRunResult on infrastructure failure
-		if (
-			result &&
-			typeof result === 'object' &&
-			'status' in result &&
-			(result as { status: string }).status === 'failed'
-		) {
-			const failedResult = result as { message?: string; failures?: number };
-			const response: ResponseMessage = {
-				id: message.id,
-				result: {
-					success: false,
-					totalTests: 0,
-					totalPassed: 0,
-					totalFailed: failedResult.failures ?? 0,
-					failures: [],
-					duration: 0,
-					error: failedResult.message ?? 'Cypress run failed',
-				},
+		const tempDir = await fs.mkdtemp(
+			path.join(os.tmpdir(), 'cypress-cli-run-'),
+		);
+		try {
+			const specFileName = path.basename(resolvedFile);
+			const e2eConfig: Record<string, unknown> = {
+				supportFile: false,
+				specPattern: specFileName,
+				video: false,
+				screenshotOnRunFailure: false,
 			};
-			conn.send(response);
-			return;
-		}
+			if (session?.config.url) {
+				try {
+					e2eConfig['baseUrl'] = new URL(session.config.url).origin;
+				} catch {
+					// Ignore invalid session URLs and run without baseUrl.
+				}
+			}
+			await fs.copyFile(resolvedFile, path.join(tempDir, specFileName));
 
-		// Normal CypressRunResult
-		const runResult = result as {
-			totalTests?: number;
-			totalPassed?: number;
-			totalFailed?: number;
-			totalDuration?: number;
-			runs?: Array<{
-				tests?: Array<{
-					title?: string[];
-					state?: string;
-					displayError?: string | null;
+			await fs.writeFile(
+				path.join(tempDir, 'cypress.config.js'),
+				`module.exports = { e2e: ${JSON.stringify(e2eConfig)} };\n`,
+				'utf-8',
+			);
+
+			await fs.writeFile(
+				path.join(tempDir, 'tsconfig.json'),
+				JSON.stringify(
+					{
+						compilerOptions: {
+							target: 'ES2020',
+							module: 'CommonJS',
+							lib: ['ES2020', 'DOM'],
+							types: ['cypress', 'node'],
+							esModuleInterop: true,
+							allowJs: true,
+							baseUrl: '.',
+						},
+						include: [specFileName],
+					},
+					null,
+					2,
+				) + '\n',
+				'utf-8',
+			);
+
+			try {
+				await fs.symlink(
+					path.resolve(process.cwd(), 'node_modules'),
+					path.join(tempDir, 'node_modules'),
+					'dir',
+				);
+			} catch {
+				// Best-effort: JS specs can still run without this, but TS specs need it.
+			}
+
+			const cypress = await import('cypress');
+			const result = await cypress.default.run({
+				project: tempDir,
+				browser: (options['browser'] as string) ?? 'electron',
+				headed: options['headed'] === true,
+			} as Record<string, unknown>);
+
+			if (
+				result &&
+				typeof result === 'object' &&
+				'status' in result &&
+				(result as { status: string }).status === 'failed'
+			) {
+				const failedResult = result as { message?: string; failures?: number };
+				const response: ResponseMessage = {
+					id: message.id,
+					result: {
+						success: false,
+						totalTests: 0,
+						totalPassed: 0,
+						totalFailed: failedResult.failures ?? 0,
+						failures: [],
+						duration: 0,
+						error: failedResult.message ?? 'Cypress run failed',
+					},
+				};
+				conn.send(response);
+				return;
+			}
+
+			const runResult = result as {
+				totalTests?: number;
+				totalPassed?: number;
+				totalFailed?: number;
+				totalDuration?: number;
+				runs?: Array<{
+					error?: string | null;
+					tests?: Array<{
+						title?: string[];
+						state?: string;
+						displayError?: string | null;
+					}>;
 				}>;
-			}>;
-		};
+			};
 
-		const failures: Array<{ test: string; error: string }> = [];
-		if (runResult.runs) {
-			for (const run of runResult.runs) {
-				if (run.tests) {
-					for (const test of run.tests) {
-						if (test.state === 'failed' && test.displayError) {
-							failures.push({
-								test: (test.title ?? []).join(' > '),
-								error: test.displayError,
-							});
+			const failures: Array<{ test: string; error: string }> = [];
+			if (runResult.runs) {
+				for (const run of runResult.runs) {
+					if (run.error) {
+						failures.push({
+							test: specFileName,
+							error: run.error,
+						});
+					}
+					if (run.tests) {
+						for (const test of run.tests) {
+							if (test.state === 'failed' && test.displayError) {
+								failures.push({
+									test: (test.title ?? []).join(' > '),
+									error: test.displayError,
+								});
+							}
 						}
 					}
 				}
 			}
-		}
 
-		const response: ResponseMessage = {
-			id: message.id,
-			result: {
-				success: (runResult.totalFailed ?? 0) === 0,
-				totalTests: runResult.totalTests ?? 0,
-				totalPassed: runResult.totalPassed ?? 0,
-				totalFailed: runResult.totalFailed ?? 0,
-				failures,
-				duration: runResult.totalDuration ?? 0,
-			},
-		};
-		conn.send(response);
+			const response: ResponseMessage = {
+				id: message.id,
+				result: {
+					success: (runResult.totalFailed ?? 0) === 0,
+					totalTests: runResult.totalTests ?? 0,
+					totalPassed: runResult.totalPassed ?? 0,
+					totalFailed: runResult.totalFailed ?? 0,
+					failures,
+					duration: runResult.totalDuration ?? 0,
+				},
+			};
+			conn.send(response);
+		} finally {
+			await fs.rm(tempDir, { recursive: true, force: true }).catch(() => {});
+		}
 	} catch (err) {
 		sendError(conn, {
 			id: message.id,

--- a/tests/unit/client/cli.test.ts
+++ b/tests/unit/client/cli.test.ts
@@ -12,8 +12,9 @@ import {
 } from '../../../src/client/cli.js';
 import type { ClientResult } from '../../../src/client/session.js';
 
-const { mockRunLocalCommand } = vi.hoisted(() => ({
+const { mockRunLocalCommand, mockStartRepl } = vi.hoisted(() => ({
 	mockRunLocalCommand: vi.fn(),
+	mockStartRepl: vi.fn(),
 }));
 
 // ---------------------------------------------------------------------------
@@ -33,6 +34,10 @@ vi.mock('../../../src/client/session.js', async (importOriginal) => {
 
 vi.mock('../../../src/client/install.js', () => ({
 	runLocalCommand: mockRunLocalCommand,
+}));
+
+vi.mock('../../../src/client/repl.js', () => ({
+	startRepl: mockStartRepl,
 }));
 
 // ---------------------------------------------------------------------------
@@ -137,6 +142,7 @@ describe('generateHelpText', () => {
 	it('includes positional argument syntax for commands', () => {
 		const help = generateHelpText();
 		expect(help).toContain('open [url]');
+		expect(help).toContain('repl');
 		expect(help).toContain('install --skills');
 		expect(help).toContain('type <ref> <text>');
 		expect(help).toContain('assert <ref> <chainer> [value]');
@@ -422,6 +428,24 @@ describe('run', () => {
 			args: {},
 			options: { skills: true },
 		});
+	});
+
+	it('runs repl locally without sending it to the daemon', async () => {
+		mockStartRepl.mockResolvedValue(undefined);
+
+		const result: CliResult = await run([
+			'--session',
+			'demo',
+			'--json',
+			'repl',
+		]);
+
+		expect(result).toEqual({ exitCode: EXIT_SUCCESS, output: '' });
+		expect(mockStartRepl).toHaveBeenCalledWith({
+			session: 'demo',
+			json: true,
+		});
+		expect(mockRunLocalCommand).not.toHaveBeenCalled();
 	});
 
 	it('returns validation error when install is missing --skills', async () => {

--- a/tests/unit/client/commands.test.ts
+++ b/tests/unit/client/commands.test.ts
@@ -12,6 +12,7 @@ import {
 	click,
 	type_,
 	navigate,
+	repl,
 	assert_,
 	snapshot,
 	open,
@@ -110,17 +111,25 @@ describe('declareCommand', () => {
 });
 
 describe('command schemas', () => {
-	it('defines all 64 commands', () => {
-		expect(allCommands).toHaveLength(64);
+	it('defines all 65 commands', () => {
+		expect(allCommands).toHaveLength(65);
 	});
 
 	it('registers all commands plus aliases in the registry', () => {
-		expect(commandRegistry.size).toBe(68);
+		expect(commandRegistry.size).toBe(69);
+	});
+
+	it('registers repl in the command registry', () => {
+		const entry = commandRegistry.get('repl');
+		expect(entry).toBeDefined();
+		expect(entry?.schema).toBe(repl);
+		expect(entry?.positionals).toEqual([]);
 	});
 
 	describe('categories', () => {
 		it('has core commands', () => {
 			expect(open.category).toBe('core');
+			expect(repl.category).toBe('core');
 			expect(stop.category).toBe('core');
 			expect(status.category).toBe('core');
 			expect(install.category).toBe('core');
@@ -513,7 +522,9 @@ describe('command schemas', () => {
 
 		it('cookie-clear requires no args or options', () => {
 			expect(cookieClear.args.safeParse({})).toMatchObject({ success: true });
-			expect(cookieClear.options.safeParse({})).toMatchObject({ success: true });
+			expect(cookieClear.options.safeParse({})).toMatchObject({
+				success: true,
+			});
 		});
 
 		it('localstorage-list requires no args', () => {
@@ -523,9 +534,9 @@ describe('command schemas', () => {
 		});
 
 		it('localstorage-get requires a key', () => {
-			expect(
-				localstorageGet.args.safeParse({ key: 'token' }),
-			).toMatchObject({ success: true });
+			expect(localstorageGet.args.safeParse({ key: 'token' })).toMatchObject({
+				success: true,
+			});
 			expect(localstorageGet.args.safeParse({})).toMatchObject({
 				success: false,
 			});
@@ -535,15 +546,15 @@ describe('command schemas', () => {
 			expect(
 				localstorageSet.args.safeParse({ key: 'token', value: 'abc' }),
 			).toMatchObject({ success: true });
-			expect(
-				localstorageSet.args.safeParse({ key: 'token' }),
-			).toMatchObject({ success: false });
+			expect(localstorageSet.args.safeParse({ key: 'token' })).toMatchObject({
+				success: false,
+			});
 		});
 
 		it('localstorage-delete requires a key', () => {
-			expect(
-				localstorageDelete.args.safeParse({ key: 'token' }),
-			).toMatchObject({ success: true });
+			expect(localstorageDelete.args.safeParse({ key: 'token' })).toMatchObject(
+				{ success: true },
+			);
 			expect(localstorageDelete.args.safeParse({})).toMatchObject({
 				success: false,
 			});
@@ -562,9 +573,9 @@ describe('command schemas', () => {
 		});
 
 		it('sessionstorage-get requires a key', () => {
-			expect(
-				sessionstorageGet.args.safeParse({ key: 'sid' }),
-			).toMatchObject({ success: true });
+			expect(sessionstorageGet.args.safeParse({ key: 'sid' })).toMatchObject({
+				success: true,
+			});
 			expect(sessionstorageGet.args.safeParse({})).toMatchObject({
 				success: false,
 			});
@@ -574,15 +585,15 @@ describe('command schemas', () => {
 			expect(
 				sessionstorageSet.args.safeParse({ key: 'sid', value: 'x' }),
 			).toMatchObject({ success: true });
-			expect(
-				sessionstorageSet.args.safeParse({ key: 'sid' }),
-			).toMatchObject({ success: false });
+			expect(sessionstorageSet.args.safeParse({ key: 'sid' })).toMatchObject({
+				success: false,
+			});
 		});
 
 		it('sessionstorage-delete requires a key', () => {
-			expect(
-				sessionstorageDelete.args.safeParse({ key: 'sid' }),
-			).toMatchObject({ success: true });
+			expect(sessionstorageDelete.args.safeParse({ key: 'sid' })).toMatchObject(
+				{ success: true },
+			);
 			expect(sessionstorageDelete.args.safeParse({})).toMatchObject({
 				success: false,
 			});
@@ -702,9 +713,9 @@ describe('command schemas', () => {
 		});
 
 		it('localstorage-get requires a key', () => {
-			expect(
-				localstorageGet.args.safeParse({ key: 'token' }),
-			).toMatchObject({ success: true });
+			expect(localstorageGet.args.safeParse({ key: 'token' })).toMatchObject({
+				success: true,
+			});
 			expect(localstorageGet.args.safeParse({})).toMatchObject({
 				success: false,
 			});
@@ -714,15 +725,15 @@ describe('command schemas', () => {
 			expect(
 				localstorageSet.args.safeParse({ key: 'token', value: 'abc' }),
 			).toMatchObject({ success: true });
-			expect(
-				localstorageSet.args.safeParse({ key: 'token' }),
-			).toMatchObject({ success: false });
+			expect(localstorageSet.args.safeParse({ key: 'token' })).toMatchObject({
+				success: false,
+			});
 		});
 
 		it('localstorage-delete requires a key', () => {
-			expect(
-				localstorageDelete.args.safeParse({ key: 'token' }),
-			).toMatchObject({ success: true });
+			expect(localstorageDelete.args.safeParse({ key: 'token' })).toMatchObject(
+				{ success: true },
+			);
 			expect(localstorageDelete.args.safeParse({})).toMatchObject({
 				success: false,
 			});
@@ -741,9 +752,9 @@ describe('command schemas', () => {
 		});
 
 		it('sessionstorage-get requires a key', () => {
-			expect(
-				sessionstorageGet.args.safeParse({ key: 'tab-id' }),
-			).toMatchObject({ success: true });
+			expect(sessionstorageGet.args.safeParse({ key: 'tab-id' })).toMatchObject(
+				{ success: true },
+			);
 			expect(sessionstorageGet.args.safeParse({})).toMatchObject({
 				success: false,
 			});
@@ -753,9 +764,9 @@ describe('command schemas', () => {
 			expect(
 				sessionstorageSet.args.safeParse({ key: 'tab-id', value: '1' }),
 			).toMatchObject({ success: true });
-			expect(
-				sessionstorageSet.args.safeParse({ key: 'tab-id' }),
-			).toMatchObject({ success: false });
+			expect(sessionstorageSet.args.safeParse({ key: 'tab-id' })).toMatchObject(
+				{ success: false },
+			);
 		});
 
 		it('sessionstorage-delete requires a key', () => {
@@ -775,28 +786,28 @@ describe('command schemas', () => {
 
 		it('console has optional level filter', () => {
 			expect(console_.args.safeParse({})).toMatchObject({ success: true });
-			expect(
-				console_.args.safeParse({ level: 'error' }),
-			).toMatchObject({ success: true });
-			expect(
-				console_.args.safeParse({ level: 'warning' }),
-			).toMatchObject({ success: true });
-			expect(
-				console_.args.safeParse({ level: 'info' }),
-			).toMatchObject({ success: true });
-			expect(
-				console_.args.safeParse({ level: 'debug' }),
-			).toMatchObject({ success: true });
-			expect(
-				console_.args.safeParse({ level: 'invalid' }),
-			).toMatchObject({ success: false });
+			expect(console_.args.safeParse({ level: 'error' })).toMatchObject({
+				success: true,
+			});
+			expect(console_.args.safeParse({ level: 'warning' })).toMatchObject({
+				success: true,
+			});
+			expect(console_.args.safeParse({ level: 'info' })).toMatchObject({
+				success: true,
+			});
+			expect(console_.args.safeParse({ level: 'debug' })).toMatchObject({
+				success: true,
+			});
+			expect(console_.args.safeParse({ level: 'invalid' })).toMatchObject({
+				success: false,
+			});
 		});
 
 		it('console --clear option is optional boolean', () => {
 			expect(console_.options.safeParse({})).toMatchObject({ success: true });
-			expect(
-				console_.options.safeParse({ clear: true }),
-			).toMatchObject({ success: true });
+			expect(console_.options.safeParse({ clear: true })).toMatchObject({
+				success: true,
+			});
 		});
 
 		it('run requires file', () => {
@@ -1319,10 +1330,7 @@ describe('parseCommand', () => {
 	});
 
 	it("parses 'localstorage-list' correctly", () => {
-		const result = parseCommand(
-			{ _: ['localstorage-list'] },
-			commandRegistry,
-		);
+		const result = parseCommand({ _: ['localstorage-list'] }, commandRegistry);
 		expect(result).toEqual({
 			command: 'localstorage-list',
 			args: {},
@@ -1367,10 +1375,7 @@ describe('parseCommand', () => {
 	});
 
 	it("parses 'localstorage-clear' correctly", () => {
-		const result = parseCommand(
-			{ _: ['localstorage-clear'] },
-			commandRegistry,
-		);
+		const result = parseCommand({ _: ['localstorage-clear'] }, commandRegistry);
 		expect(result).toEqual({
 			command: 'localstorage-clear',
 			args: {},

--- a/tests/unit/client/open.test.ts
+++ b/tests/unit/client/open.test.ts
@@ -117,6 +117,38 @@ describe('openSession', () => {
 		expect(result.success).toBe(true);
 	});
 
+	it('strips stale page metadata from failed reused-session open results', async () => {
+		const sendCommand = vi.fn().mockResolvedValue({
+			success: false,
+			error: '503 Service Unavailable',
+			result: {
+				error: '503 Service Unavailable',
+				snapshot: '- heading "Old Page"',
+				snapshotFilePath: '.cypress-cli/page-old.yml',
+				url: 'https://example.cypress.io/commands/actions',
+				title: 'Cypress.io: Kitchen Sink',
+			},
+		} satisfies ClientResult);
+
+		const result = await openSession(
+			buildOpenCommand('https://httpstat.us/503'),
+			'demo',
+			{
+				createSession: () => ({ sendCommand }),
+			},
+		);
+
+		expect(sendCommand).toHaveBeenCalledWith({
+			command: 'navigate',
+			args: { url: 'https://httpstat.us/503' },
+			options: {},
+		});
+		expect(result).toEqual({
+			success: false,
+			error: '503 Service Unavailable',
+		});
+	});
+
 	it('spawns the daemon and polls until the session is ready', async () => {
 		const sendCommand = vi
 			.fn()

--- a/validation/LLM_VALIDATION_LOG.md
+++ b/validation/LLM_VALIDATION_LOG.md
@@ -1,0 +1,502 @@
+# LLM Validation Log
+
+> Running log maintained during the 1.0 validation runbook.
+> Each entry is appended after completing a step from `docs/LLM_VALIDATION_RUNBOOK.md`.
+
+## Format
+
+Each entry follows this structure:
+
+### Step N.N — [Step Title] — [YYYY-MM-DD HH:MM]
+
+**Status:** Pass / Fail / Partial / Blocked
+
+**Observations:**
+
+- [What happened]
+
+**Problems Found:**
+
+- [Description] → [Severity: blocker / should-fix / nice-to-have] → [Action: filed #N / fixed inline / deferred]
+
+**Launch Plan Notes:**
+
+- [Any observations about `docs/LAUNCH_PLAN.md` — is anything missing, wrong, or needs updating?]
+
+---
+
+## Entries
+
+### Step 0 — Documentation Review — 2026-04-10 14:32
+
+**Status:** Complete
+
+**Observations:**
+
+- The project is a Cypress-backed browser automation CLI for LLMs: a one-shot client talks to a persistent daemon over a Unix socket, the daemon feeds commands into a Cypress driver loop via `cy.task()`, and each command returns page metadata plus a snapshot file path instead of inline DOM output.
+- The documented command surface is 64 commands with 68 registry entries including aliases, and the current validation target is broader than the prior `validation/FINDINGS.md` run, which covered 43 commands across 73 live steps.
+- The documented current baseline is 1009 passing tests across 52 files, green CI, and one explicit 1.0 blocker: issue #73 for long-running LLM validation.
+- The docs consistently position aria snapshots, resilient session recovery, and exportable Cypress code as the main launch differentiators versus `playwright-cli`, with known Cypress limits called out honestly (single tab, no PDF, limited hover fidelity, no runtime tracing/video).
+- The existing validation materials are strong enough to execute the runbook, but they include a mix of historical state (`validation/FINDINGS.md`, generated example tests) and current state (`docs/LAUNCH_PLAN.md`, `docs/ROADMAP.md`), so date/context matters when comparing claims.
+
+**Problems Found:**
+
+- `docs/LLM_VALIDATION_RUNBOOK.md` requires a Step 1 comparison against `docs/READINESS_ASSESSMENT.md` but does not include that file in the Step 0 required-reading list → Severity: nice-to-have → Action: deferred
+- `skills/cypress-cli/SKILL.md` documents the snapshot output as plain text (`Snapshot → ...`) while the current docs and expected CLI output use a markdown link format (`[Snapshot](...)`) → Severity: should-fix → Action: deferred
+
+**Launch Plan Notes:**
+
+- The launch plan correctly treats #73 as the release blocker, but its Step 1.1 description is narrower than the runbook: the runbook adds explicit new-command coverage, error recovery checks, export-quality review, and skill/package audits that should probably be referenced from the plan for completeness.
+- The 1–2 day Phase 1 estimate may be optimistic if the live sites are flaky or if even a small number of usability issues require investigation, because the validation scope is materially larger than the earlier 73-step run.
+
+### Step 1 — Build and Verify Baseline — 2026-04-10 14:34
+
+**Status:** Pass
+
+**Observations:**
+
+- `npm run build` completed successfully with the injected IIFE bundle, driver spec bundle, and TypeScript compilation all succeeding.
+- `npx vitest run` passed with 52 test files and 1009 passing tests; there were 0 failing test files and 0 failing tests.
+- `npx tsc --noEmit` completed with zero output, indicating a clean typecheck.
+- `npx eslint src/ tests/` completed with zero output, consistent with 0 lint errors and 0 warnings.
+- The main readiness baseline in `docs/READINESS_ASSESSMENT.md` matches the observed build/test/typecheck/lint counts exactly: 1009 tests, 52 files, clean build, clean typecheck, and clean lint.
+
+**Problems Found:**
+
+- `npx vitest run` emitted repeated `Couldn't find tsconfig.json. tsconfig-paths will be skipped` messages during Cypress-backed tests even though `docs/READINESS_ASSESSMENT.md` says the tsconfig-paths warnings were addressed → Severity: should-fix → Action: deferred
+- `npx vitest run` emitted a `MaxListenersExceededWarning` on a `Socket` during the navigation e2e slice; it did not fail the suite, but it is a real runtime warning in the baseline → Severity: should-fix → Action: deferred
+
+**Launch Plan Notes:**
+
+- The launch plan's stated current baseline (64 commands, 1009 passing tests, green CI) is accurate as of this run.
+- The plan does not mention baseline runtime warnings; if the team wants a stricter 1.0 gate than "tests pass," it may be worth explicitly deciding whether repeated non-fatal warnings are acceptable release noise.
+
+### Step 2.1 — Scenario 1: TodoMVC — 2026-04-10 14:47
+
+**Status:** Pass
+
+**Observations:**
+
+- The full TodoMVC scenario completed end-to-end with the local CLI: `open`, `asserttitle`, three `type` + `press Enter` cycles, `check`, filter `click`s, footer `assert`, `export`, `run`, and `stop`.
+- Every interactive command returned the expected structured CLI output (`### Page` plus `### Snapshot`), and the emitted snapshot files were readable diff snapshots that made the changed state obvious.
+- The initial snapshot exposed the expected input ref (`e9`), and the manual flow kept refs understandable across incremental changes: first-item checkbox `e22`, items-left container `e25`, and filter links `e29`/`e31`/`e33` were all usable without trial-and-error.
+- Snapshot diffs correctly showed footer count changes (`3` → `2` items left), filter activation, and view-specific list contents when switching between All / Active / Completed.
+- The exported test file was syntactically valid and, after an inline fix to the `run` command, `node bin/cypress-cli run /tmp/cypress-cli-validation/todomvc.cy.ts` passed with `Total: 1`, `Passed: 1`, `Failed: 0`.
+
+**Problems Found:**
+
+- `run` initially failed on exported `.cy.ts` files with `Could not find Cypress test run results` because it launched Cypress without a temporary project/config context; fixed inline by running specs inside a temp Cypress project with a minimal config + temp `tsconfig.json` + `node_modules` symlink → Severity: blocker → Action: fixed inline
+- Selector quality in the exported TodoMVC test was mixed: the input selector was clean (`input.new-todo`) and the count assertion used `[data-testid="todo-count"]`, but the checkbox and filter links still exported as long `html > body > ... > nth-of-type(...)` chains → Severity: should-fix → Action: deferred
+
+**Launch Plan Notes:**
+
+- The launch plan should assume this validation can surface real shipping bugs even after a green baseline; the TodoMVC rerun found a release-relevant `run` bug that the existing automated tests did not catch.
+- The plan's Step 1.1 wording focuses on "does export pass `cypress-cli run`?" but not on validating the `run` command itself as a standalone feature; that distinction mattered here.
+
+### Step 2.3 — Scenario 2: SauceDemo — 2026-04-10 14:54
+
+**Status:** Pass
+
+**Observations:**
+
+- The full SauceDemo purchase flow completed with the local CLI: login, URL assertion, screenshot, sort low-to-high, add two items, cart verification, checkout form, finish, confirmation assertion, screenshot, export, exported test run, and stop.
+- Command output format stayed consistent across the scenario, and the snapshot diffs remained readable enough to track the key state transitions: sorted inventory order, cart badge `1` → `2`, checkout page transitions, and final confirmation heading.
+- Selector/codegen quality was strong on this site because the app exposes `data-test` attributes; the exported test used clean selectors throughout and `--baseUrl https://www.saucedemo.com` correctly produced `cy.visit('/')` in the generated file.
+- After a second inline fix to the `run` command, the exported test passed through `node bin/cypress-cli run /tmp/cypress-cli-validation/saucedemo.cy.ts` with `Total: 1`, `Passed: 1`, `Failed: 0`.
+
+**Problems Found:**
+
+- Exported tests that rely on `--baseUrl` initially failed under `run` because the temporary Cypress project did not inherit a `baseUrl`, so `cy.visit('/')` tried to load from the temp directory; fixed inline by deriving `e2e.baseUrl` from the active session origin when available → Severity: blocker → Action: fixed inline
+- The cart navigation control was not exposed as a clearly labeled cart link/icon in the aria snapshot after items were added; only the badge ref (`e146`) was visible and clickable, which is workable but discoverability-poor for an LLM following the scenario literally → Severity: should-fix → Action: deferred
+
+**Launch Plan Notes:**
+
+- The launch plan should explicitly expect exported-test execution bugs in addition to interaction bugs; this scenario showed that `export` and `run` need to be validated together on sites that use `baseUrl`-relative visits.
+- SauceDemo is a good confidence site for 1.0 because it exercises modern, data-attribute-rich selectors and multi-page state, but it does not stress weak-selector codegen the way less-instrumented sites will.
+
+### Step 2.5 — Scenario 3: The Internet — 2026-04-10 14:57
+
+**Status:** Blocked
+
+**Observations:**
+
+- Scenario 3 could not proceed because `https://the-internet.herokuapp.com` was unavailable during this run. Direct HTTP checks against both `/` and `/checkboxes` returned `503 Service Unavailable`, and retrying `node bin/cypress-cli open https://the-internet.herokuapp.com` failed with Cypress surfacing the same `503` response from `cy.visit()`.
+- Because the initial page load never succeeded, none of the intended multi-page coverage for checkboxes, dropdowns, login, dialogs, key presses, hover, or tables could be exercised in this session.
+- This was not a general session-startup regression: `node bin/cypress-cli open https://example.cypress.io` succeeded immediately in the same environment, which narrowed the failure to the external target site.
+
+**Problems Found:**
+
+- External dependency outage: The Internet playground returned `503` consistently, blocking the full scenario → Severity: blocker for this scenario, not for the product → Action: deferred and documented
+- On the failed retry, the CLI still printed `### Page` metadata and a snapshot path from the previously open `example.cypress.io` session after the `cy.visit()` failure, which is misleading because the new `open` did not actually establish the requested session target → Severity: should-fix → Action: deferred
+
+**Launch Plan Notes:**
+
+- The launch plan's requirement of "at least 3 different sites" remains achievable, but the runbook should explicitly account for third-party site outages by allowing a substitute target or a clearly documented blocked scenario without forcing ad hoc interpretation mid-run.
+- This run reinforces that the 1.0 confidence gate depends partly on external site stability; the launch plan should distinguish product regressions from validation-environment failures so launch decisions are based on the right signal.
+
+### Step 2.7 — Scenario 4: RealWorld Conduit — 2026-04-10 15:01
+
+**Status:** Pass
+
+**Observations:**
+
+- The full Conduit stateful workflow completed with the local CLI: open, sign up, login-state verification, article creation, article assertions, screenshot, comment creation, feed navigation, export, exported test run, and stop.
+- This scenario provided the strongest real-world confidence signal of the run so far because it exercised a multi-step SPA flow where later actions depended on earlier state: registration established auth, auth enabled editor navigation, publish created a durable article slug, comment creation updated the article view, and the created article then appeared in Global Feed.
+- The exported test file was coherent and meaningful: it used `cy.visit('/')` because of `--baseUrl https://demo.realworld.show`, preserved the full workflow in sequence, and `node bin/cypress-cli run /tmp/cypress-cli-validation/conduit.cy.ts` passed with `Total: 1`, `Passed: 1`, `Failed: 0`.
+
+**Problems Found:**
+
+- SPA navigation/snapshot timing remained slightly inconsistent: after clicking `Sign up`, the immediate CLI output still showed `/` and a home-feed snapshot until an explicit URL assertion / fresh snapshot was taken, and a later `navigate https://demo.realworld.show` produced a one-line snapshot file (`- document [ref=e1]`) before the next snapshot captured the settled page → Severity: should-fix → Action: deferred
+- Export/codegen selector quality was mixed on Conduit: some selectors were clean (`input[name="username"]`, `input[name="email"]`, `textarea[name="body"]`), but others relied on long absolute DOM paths and transient Angular state classes like `input.form-control.ng-untouched.ng-pristine` / `textarea.form-control.ng-untouched.ng-pristine`, which replayed successfully here but are brittle → Severity: should-fix → Action: deferred
+
+**Launch Plan Notes:**
+
+- Conduit satisfies the launch plan's need for a meaningful third real-world workflow even with Scenario 3 blocked, because it validates the most important 1.0 claim: an LLM can drive a real browser through a long stateful flow and export a runnable Cypress test from it.
+- The launch plan should probably treat SPA-settling behavior and selector robustness as explicit usability criteria, not just correctness criteria, because both directly affect how well an LLM can stay oriented without human intervention.
+
+### Step 3.1 — Storage Commands — 2026-04-10 15:03
+
+**Status:** Partial
+
+**Observations:**
+
+- The core storage commands worked against `https://example.cypress.io/commands/actions`: `localstorage-set/get/list/delete`, `sessionstorage-set/get/list/delete/clear`, and `cookie-set` all returned sensible structured results and mutated browser state as expected.
+- `state-save` successfully captured cookies and localStorage into the default `.cypress-cli/state.json` file, and `state-load .cypress-cli/state.json` restored both the cookie (`myCook=testVal`) and localStorage entry (`myKey=myVal`) when invoked with the actual required filename.
+- The storage command implementations themselves are usable, but the exact runbook sequence did not pass cleanly as written because two assumptions in the runbook no longer match current behavior.
+
+**Problems Found:**
+
+- The runbook's exact command `node bin/cypress-cli state-load` is invalid for the current CLI: `state-load` now requires a filename argument, while `state-save` defaults to `.cypress-cli/state.json`; this is both a docs mismatch and a discoverability problem because the paired commands no longer compose from the human-readable output alone → Severity: should-fix → Action: deferred
+- `state-save` wrote `.cypress-cli/state.json`, but the non-JSON CLI output did not surface the written file path even though the file existed on disk, forcing manual discovery before `state-load` could succeed → Severity: should-fix → Action: deferred
+- The exact runbook step `node bin/cypress-cli navigate https://example.com` failed in this environment with a Cypress `cy.visit()` network-level `socket hang up`, so the full save-navigate-clear-restore flow could not be validated against that target exactly as written → Severity: nice-to-have → Action: deferred and documented
+
+**Launch Plan Notes:**
+
+- The launch plan and runbook should explicitly guard against command-syntax drift in validation scripts. Storage/state commands are especially sensitive because their usability depends on multi-command composition, not just individual command success.
+- For 1.0 confidence, storage validation should prefer a stable same-origin or known-reachable target over `https://example.com`, since the point of the step is state restoration behavior rather than third-party network reachability.
+
+### Step 3.3 — Console Command — 2026-04-10 15:03
+
+**Status:** Pass
+
+**Observations:**
+
+- `node bin/cypress-cli run-code "console.log('hello from validation')"` executed successfully against `https://example.cypress.io/`, and `node bin/cypress-cli console` returned a structured JSON array containing the emitted message.
+- The captured console entry preserved the key fields an LLM would need to reason about logs: `level`, `text`, and `timestamp`. The observed output was `[{"level":"info","text":"hello from validation","timestamp":"2026-04-10T19:03:39.508Z"}]`.
+- This feature is materially useful for launch because it gives the agent a lightweight way to inspect application-side diagnostics without opening DevTools or injecting more invasive instrumentation.
+
+**Problems Found:**
+
+- No product issues found in this slice.
+
+**Launch Plan Notes:**
+
+- The launch plan should treat console capture as one of the strongest differentiators for debugging-oriented LLM workflows, not just a secondary command. It worked cleanly and adds real value beyond DOM-only snapshots.
+
+### Step 3.5 — Network Commands — 2026-04-10 15:04
+
+**Status:** Partial
+
+**Observations:**
+
+- `network`, `intercept`, `intercept-list`, and `unintercept` all worked against `https://jsonplaceholder.typicode.com/`. The initial `network` output returned a structured list of requests with URL, method, status, content type, size, timestamp, and `activeRouteCount`, which is a useful debugging surface for an LLM.
+- Intercept registration state stayed coherent: registering `**/posts` reported `activeRouteCount: 1`, `intercept-list` showed the configured route, and `unintercept` removed it cleanly back to `activeRouteCount: 0` with an empty intercept list.
+- The exact runbook step `navigate https://jsonplaceholder.typicode.com/posts` is not a valid Cypress `visit()` target because that URL serves JSON (`application/json`), not HTML. As a follow-up validation, a browser-side `fetch('/posts')` with the intercept active logged `posts-body []` to the captured console, which confirmed the intercept actually affected live requests as intended.
+
+**Problems Found:**
+
+- The runbook's exact navigation target is wrong for Cypress semantics: `cy.visit()` rejects `https://jsonplaceholder.typicode.com/posts` because the response is JSON rather than HTML, so the step does not cleanly validate request interception as written → Severity: should-fix → Action: deferred
+- Because the invalid `navigate` step fails before a `/posts` page load can occur, the runbook currently under-validates whether the intercept changed live traffic unless the operator improvises a follow-up request (for example, `fetch('/posts')`) → Severity: should-fix → Action: deferred
+
+**Launch Plan Notes:**
+
+- The launch plan/runbook should distinguish between page navigation validation and network interception validation. Those are related but not the same, and using a raw JSON endpoint as a navigation target muddies the signal.
+- Network tooling looks launch-worthy, but the validation script should use either an HTML page that fetches the target API or an explicit browser-side request step so the intercept behavior is exercised intentionally rather than accidentally.
+
+### Step 3.7 — Execution Commands — 2026-04-10 15:05
+
+**Status:** Partial
+
+**Observations:**
+
+- `eval` behaved well: `node bin/cypress-cli eval "document.title"` returned the expected page title string, `"Cypress.io: Kitchen Sink"`.
+- `run-code` also behaved well for simple synchronous browser expressions: `node bin/cypress-cli run-code "document.querySelectorAll('input').length"` returned `20`, which is a sensible and directly useful result.
+- `cyrun` executed successfully and preserved page metadata, but it did not surface the yielded chain value from `cy.url().then(u => u)` in either the human-readable output or the JSON payload. The command confirmed success and the current page URL via metadata, but not via the chain result itself.
+
+**Problems Found:**
+
+- `cyrun` is execution-capable but result-poor from the CLI perspective: a chain like `cy.url().then(u => u)` runs successfully, yet the yielded value is not exposed back to the caller, which makes `cyrun` less useful for exploratory agent workflows than `eval` or `run-code` → Severity: should-fix → Action: deferred
+
+**Launch Plan Notes:**
+
+- The launch plan should distinguish the three execution surfaces more clearly: `eval` and `run-code` are good for value-returning introspection, while `cyrun` is currently better suited to imperative Cypress actions than to returning data.
+
+### Step 3.9 — Run Command — 2026-04-10 15:06
+
+**Status:** Pass
+
+**Observations:**
+
+- Exporting the current session to `/tmp/validation-test.cy.ts` succeeded, and `node bin/cypress-cli run /tmp/validation-test.cy.ts` returned the expected structured run summary.
+- The observed output format was correct and launch-usable: `### Test Run: PASSED`, `Total: 1`, `Passed: 1`, `Failed: 0`, and `Duration: 239ms`.
+- This gives additional confirmation that the earlier inline `run` fixes did not only repair the scenario-specific exports; the dedicated command still behaves correctly on a simple exported session.
+
+**Problems Found:**
+
+- No product issues found in this slice.
+
+**Launch Plan Notes:**
+
+- The launch plan's emphasis on exported-test replay is justified. At this point the tool has passed explicit `run` validation on simple exports and on the stronger TodoMVC, SauceDemo, and Conduit workflows.
+
+### Step 3.11 — REPL Mode — 2026-04-10 15:08
+
+**Status:** Fail
+
+**Observations:**
+
+- The exact runbook command `node bin/cypress-cli repl` failed immediately with `Error: Unknown command "repl". Run cypress-cli --help for available commands.`
+- The public CLI help output does not list a `repl` command at all.
+- There is still REPL-related implementation code in the repository (`src/client/repl.ts` and related references), so this looks like feature/docs drift rather than a fully removed concept. However, as shipped and validated from the user-facing CLI surface, REPL mode is not available.
+
+**Problems Found:**
+
+- The runbook expects a public `repl` command that the actual CLI does not expose, so the REPL workflow cannot be validated or used from the documented interface → Severity: should-fix → Action: deferred
+
+**Launch Plan Notes:**
+
+- The launch plan/runbook should either remove REPL from the validation scope or the product should restore/expose it intentionally. Carrying dead or inaccessible interaction modes into 1.0 validation creates avoidable ambiguity about what is actually part of the launch surface.
+
+### Step 4 — Error Recovery Validation — 2026-04-10 15:09
+
+**Status:** Partial
+
+**Observations:**
+
+- Bad-ref recovery behaved well: `node bin/cypress-cli click e99999` returned an actionable error (`Ref "e99999" not found in current snapshot. Run snapshot to refresh the element map.`), and a subsequent `snapshot` command still worked, confirming the session stayed alive.
+- Invalid-argument handling also behaved well. `assert`, `type`, and `navigate` with missing required arguments each returned clear validation errors naming the missing fields instead of crashing.
+- Post-stop behavior was correct: after `node bin/cypress-cli stop`, a subsequent `snapshot` returned `No session "default" found. Run cypress-cli open <url> to start a session.`
+- Double-open behavior is mostly sound when the second URL is reachable: after the runbook's failing `open https://example.com`, a follow-up `open https://example.cypress.io/commands/actions` replaced the active page cleanly.
+
+**Problems Found:**
+
+- When `open` fails on an unreachable target like `https://example.com`, the CLI still prints page metadata and a snapshot from the previously active session, which is misleading because the requested new page was not actually opened → Severity: should-fix → Action: deferred
+- The exact runbook double-open target `https://example.com` failed in this environment with a network-level `socket hang up`, so the double-open semantics had to be disambiguated with a reachable follow-up URL → Severity: nice-to-have → Action: deferred and documented
+
+**Launch Plan Notes:**
+
+- The launch plan should count actionable, non-crashing errors as a real release strength. Bad refs and bad args were handled well enough for an LLM to self-correct.
+- The runbook should use a reliably reachable second URL for the double-open check, otherwise the validation signal gets mixed between session-replacement behavior and third-party network reachability.
+
+### Step 5 — Export Quality Audit — 2026-04-10 15:11
+
+**Status:** Partial
+
+**Observations:**
+
+- A comprehensive 15+ command session was executed across `https://example.cypress.io/commands/actions` and `https://example.cypress.io/commands/waiting`, covering navigation, `type`, `fill`, `clear`, `select`, `check`, `assert`, `asserturl`, `asserttitle`, `waitfor`, and `screenshot`.
+- The exported file `/tmp/comprehensive.cy.ts` was valid TypeScript, had the expected `describe()` / `it()` structure, emitted correct Cypress commands, and did not leak meta-commands like `snapshot`, `history`, or `status` into the generated test.
+- The exported test replayed successfully via `node bin/cypress-cli run /tmp/comprehensive.cy.ts` with `Total: 1`, `Passed: 1`, `Failed: 0`, which is the strongest confirmation that the generated code is structurally sound.
+- A positive detail: the one failed interactive command during the session (`assert ... have.value ''`) was not exported into the test history, so the generated file reflected the successful flow rather than preserving a known-bad command.
+
+**Problems Found:**
+
+- CLI ergonomics around empty-string assertions are weak: `node bin/cypress-cli assert e91 have.value ''` was parsed as if no expected value had been provided, which makes it awkward to express valid assertions against an empty string through the shell/argument parser → Severity: should-fix → Action: deferred
+- Selector quality in the exported test was mixed. Several selectors were good (`#email1`, `#fullName1`, `#description`, `select.form-control.action-select`, `button.network-btn.btn.btn-primary`), but the checked checkbox still exported as a long absolute DOM path (`#actions > div > div:nth-of-type(26) > ... > input`), which is replayable here but fragile → Severity: should-fix → Action: deferred
+
+**Launch Plan Notes:**
+
+- The launch plan should treat "export omits failed commands and replays the successful path" as an explicit quality criterion, because that behavior materially improves the usefulness of generated tests from imperfect interactive sessions.
+- Export quality is close to launch-ready, but selector resilience still deserves explicit weight in the 1.0 decision, especially on pages without strong semantic attributes.
+
+### Step 6 — SKILL File and Agent Discoverability — 2026-04-10 15:12
+
+**Status:** Partial
+
+**Observations:**
+
+- Skill installation worked correctly. `node bin/cypress-cli install --skills` recreated `.github/skills/cypress-cli/` with the expected `SKILL.md` plus `references/` directory.
+- The packaged skill is discoverable in the intended location, so the mechanical part of the agent-integration workflow is solid.
+- The content, however, is not fully aligned with the current CLI surface or output behavior, which matters because this file is supposed to teach other agents how to use the tool correctly without fallback human interpretation.
+
+**Problems Found:**
+
+- The installed `SKILL.md` still shows the old snapshot output format (`Snapshot → .cypress-cli/...`) even though the actual CLI emits a markdown-style link (`[Snapshot](...)`) under `### Snapshot` → Severity: should-fix → Action: deferred
+- Command coverage in the skill is incomplete relative to the current 64-command surface. Important commands exercised in this validation, including storage commands (`cookie-*`, `localstorage-*`, `sessionstorage-*`, `state-save`, `state-load`), `console`, `eval`, `cyrun`, and `run`, are omitted from the main command table → Severity: should-fix → Action: deferred
+- The workflow example is inaccurate for `run-code`: it suggests `cypress-cli run-code "cy.get('#modal').should('be.visible')"`, but `run-code` executes browser-side JavaScript via `window.eval(...)`, not Cypress chain code, so that example is misleading → Severity: should-fix → Action: deferred
+
+**Launch Plan Notes:**
+
+- The launch plan is right to emphasize agent discoverability, but installation alone is not enough. For 1.0, the packaged skill content itself needs to be treated as release documentation and validated with the same discipline as the README.
+
+### Step 7 — README and Package Audit — 2026-04-10 15:15
+
+**Status:** Pass
+
+**Observations:**
+
+- `README.md` now matches the currently exposed CLI surface for the audited area: the stale `cypress-cli repl` section was removed inline, while the install instructions already referenced the published package name (`cypress-cli`) rather than local paths.
+- `npm pack --dry-run` now includes the full expected release metadata set: `README.md`, `LICENSE`, `THIRD_PARTY_LICENSES`, `bin/`, `dist/`, `skills/`, and `package.json`.
+- The dry-run tarball remained clean after the manifest fix: no unexpected `tests/`, `node_modules/`, or `.github/` content was included, and the package size remained modest at about 180 kB compressed.
+
+**Problems Found:**
+
+- `package.json` initially omitted `THIRD_PARTY_LICENSES` from the `files` allowlist, so the dry-run tarball did not include it; fixed inline by adding `THIRD_PARTY_LICENSES` to `files` and rerunning `npm pack --dry-run` to confirm inclusion → Severity: should-fix → Action: fixed inline
+- `README.md` initially advertised `cypress-cli repl` even though the public CLI does not expose a `repl` command; fixed inline by removing the stale REPL section from the README → Severity: should-fix → Action: fixed inline
+
+**Launch Plan Notes:**
+
+- The launch plan's package checklist was useful and specific enough to catch a real release artifact omission before publish; keeping the required `files` list explicit is paying off.
+- README/package audit should remain a hard pre-release gate for 1.0, because both issues found here were user-facing release problems that would not have been caught by the green build/test baseline.
+
+### Step 8 — Final Assessment — 2026-04-10 15:16
+
+**Status:** Fail
+
+**Observations:**
+
+- The final results document was written to `validation/LLM_VALIDATION_RESULTS.md` after re-reading the launch plan, the full live validation log, the prior `validation/FINDINGS.md`, and `docs/READINESS_ASSESSMENT.md`.
+- Baseline health is strong: build, tests, typecheck, and lint all passed; real end-to-end export/replay workflows passed on TodoMVC, SauceDemo, and RealWorld Conduit; and two release-relevant `run` defects were fixed inline during the validation.
+- The package audit also ended in a better state than it started: `THIRD_PARTY_LICENSES` is now included in the dry-run tarball, and the README no longer advertises a public `repl` command that does not exist.
+- Despite that progress, the full run still leaves user-facing inconsistencies on the launch surface: failed `open` output can be misleading, the packaged skill file is stale/incomplete, and the docs/validation surface still disagree about whether REPL mode is part of the product.
+
+**Problems Found:**
+
+- Remaining blocker: failed `open` requests can return stale page metadata and snapshot paths from the previously active session, which is misleading for agent-driven workflows and needs to be fixed before 1.0 → Severity: blocker → Action: deferred
+- Remaining blocker: the packaged `.github/skills/cypress-cli/SKILL.md` still teaches outdated output and omits important commands, so agent discoverability is not yet launch-ready → Severity: blocker → Action: deferred
+- Remaining blocker: REPL mode is still treated as supported by parts of the validation/readiness documentation, but the public CLI does not expose it; 1.0 needs a consistent product/docs decision here → Severity: blocker → Action: deferred
+
+**Launch Plan Notes:**
+
+- The launch plan should be updated to reflect that the 1.0 confidence gate is not just "three sites plus green tests"; in practice it also depends on `run` replay, truthful error output, skill accuracy, and package correctness.
+- Phase 1 timing should likely be loosened or explicitly conditioned on stable validation targets, because live-site outages and validation-script drift consumed meaningful effort even in a mostly successful run.
+
+### Fix 1 — Failed Open Stale Output — 2026-04-10 15:46
+
+**Status:** Partial
+
+**Observations:**
+
+- Root cause confirmed in the client reuse path: `openSession()` turns a second `open <url>` into `navigate <url>` against the existing session, and on failure it was returning the raw failed `navigate` result. That generic failure payload legitimately included the current page URL/title/snapshot from the still-alive prior page, which is useful for most command failures but misleading for `open` specifically.
+- `src/daemon/session.ts` does not mutate stored URL/title during this flow, so this was not session-state corruption. The smallest safe fix was in `src/client/open.ts`, with a focused regression test added in `tests/unit/client/open.test.ts`.
+- The fix now strips page/snapshot fields from failed reused-session `open` results and leaves only the error. Because the sanitization happens after any failed reused `navigate` result, it is agnostic to whether `cy.visit()` failed due to network error, 4xx/5xx response, or timeout. Cold-start `open` failures already surface through daemon startup failure rather than stale prior-page metadata.
+- Required regression checks passed after the change: `npx tsc --noEmit`, `npx vitest run`, and `npx eslint src/ tests/`.
+
+**Problems Found:**
+
+- The driver/daemon error path intentionally preserves current page state for generic command failures, so fixing this at the daemon layer would have widened behavior for unrelated commands. The correct scope for this blocker was the client-side `open` reuse path.
+
+**Verification:**
+
+- [x] Error-only output on failed open
+- [ ] Session stays alive after failed open
+- [ ] Subsequent valid open works
+- [x] npx vitest run passes
+- [x] npx tsc --noEmit passes
+
+### Fix 2 — SKILL.md Update — 2026-04-10 15:50
+
+**Status:** Pass
+
+**Observations:**
+
+- Rewrote `skills/cypress-cli/SKILL.md` around the actual current CLI surface instead of the stale subset. The file now has a correct output-format example, grouped command tables, refreshed workflow guidance, and explicit distinctions between browser-side JavaScript (`run-code`, `eval`) and Cypress runner code (`cyrun`).
+- The rewritten command reference covers the full current 64-command surface from `src/client/commands.ts`, and also documents `repl` to match the already-chosen Step 3 decision to expose it publicly.
+- Additional inaccuracies surfaced during the rewrite: `docs/COMMANDS.md` lags the actual source for some already-implemented commands such as `fill`, `screenshot`, `drag`, `upload`, `dialog-accept`, `dialog-dismiss`, and `resize`, so `src/client/commands.ts` was the more reliable source of truth for the packaged skill content.
+- `node bin/cypress-cli install --skills` succeeded, recreated `.github/skills/cypress-cli`, and the installed `SKILL.md` matched the edited source exactly. Required regression checks also passed: `npx tsc --noEmit`, `npx vitest run`, and `npx eslint src/ tests/`.
+
+**Problems Found:**
+
+- No issues with `install --skills` or file placement. The installer correctly replaces the target directory with the updated packaged source.
+
+**Verification:**
+
+- [x] Output format matches CLI
+- [x] All 64 commands represented
+- [x] run-code example is browser-side JS
+- [x] cyrun documented with Cypress chain example
+- [x] install --skills works correctly
+
+### Fix 3 — REPL Wired Up — 2026-04-10 15:53
+
+**Status:** Partial
+
+**Observations:**
+
+- Wired the already-existing REPL implementation into the public CLI surface by registering `repl` in `src/client/commands.ts` and dispatching it from `src/client/cli.ts` before the daemon-send path. The Step 2 skill update already documented this chosen public surface.
+- Updated the public-surface tests in `tests/unit/client/commands.test.ts` and `tests/unit/client/cli.test.ts` so the command is counted, present in the registry, shown in help output, and dispatched locally through `startRepl()`.
+- The new public counts are `allCommands.length === 65` and `commandRegistry.size === 69` (65 commands plus 4 aliases). Focused REPL wiring tests passed, and the required regression checks also passed: `npx tsc --noEmit`, `npx vitest run`, and `npx eslint src/ tests/`.
+
+**Problems Found:**
+
+- No unexpected implementation issues. The existing `src/client/repl.ts` behavior was already covered by its own unit tests; this step was strictly about public registration and dispatch.
+
+**Verification:**
+
+- [ ] `node bin/cypress-cli repl` enters interactive mode
+- [ ] Commands execute in REPL
+- [ ] exit/Ctrl+D works
+- [x] --help lists repl
+- [x] Command count tests updated and passing
+- [x] npx vitest run passes
+- [x] npx tsc --noEmit passes
+
+### Fix 4 — Re-Validation — 2026-04-10 15:58
+
+**Status:** Pass
+
+**Baseline:**
+
+- Build: pass
+- Typecheck: pass
+- Tests: 1012 passing, 0 failing
+- Lint: 0 errors, 0 warnings
+
+**Fix 1 Re-Validation:**
+
+- Failed open output: clean error only. `node bin/cypress-cli open https://httpstat.us/503` returned the Cypress network error without any `### Page` or `### Snapshot` section.
+- Session alive after failed open: yes. `node bin/cypress-cli snapshot` immediately after the failed open still returned the existing `https://example.cypress.io/commands/actions` page state.
+- Recovery open: success. A follow-up `node bin/cypress-cli open https://example.cypress.io/commands/actions` succeeded normally and returned fresh page metadata plus snapshot output.
+
+**Fix 2 Re-Validation:**
+
+- install --skills: success
+- Output format correct: yes
+- Command coverage complete: yes
+- Examples accurate: yes
+
+**Fix 3 Re-Validation:**
+
+- REPL behavior: matches chosen option. The public `node bin/cypress-cli repl` path now reaches a live prompt, and executing `snapshot` then `exit` through the shipped REPL command returned snapshot output and exited cleanly with `Goodbye.`
+
+**Problems Found:**
+
+- No product issues found during live re-validation. One VS Code terminal integration quirk closed stdin before interactive injection in the async terminal helper, so the REPL command sequence was completed by feeding `snapshot` and `exit` through the same public `node bin/cypress-cli repl` command via stdin, which still exercised the shipped REPL path end to end.
+
+**Verdict:**
+
+- [x] All three fixes confirmed working live
+- [x] Ready to proceed to Step 5 (doc cleanup)
+
+### Fix 5 — Doc Cleanup — 2026-04-10 16:04
+
+**Status:** Pass
+
+**Observations:**
+
+- Updated the release-facing docs that were still contradicting the validated product state: `docs/READINESS_ASSESSMENT.md`, `docs/COMMANDS.md`, `docs/LAUNCH_PLAN.md`, `docs/ROADMAP.md`, and `docs/LLM_VALIDATION_RUNBOOK.md`.
+- Corrected the readiness assessment to reflect the current baseline (1012 passing tests, 52 files), the public REPL command, the 65-command surface, and the fact that `tsconfig-paths` plus `MaxListenersExceededWarning` are still present as known non-blocking warning noise rather than resolved issues.
+- Brought the command reference and release-planning docs back in sync with the shipped CLI surface by adding the missing public command rows in `docs/COMMANDS.md` and updating 64-command references to 65-command references where those docs describe the current release surface.
+- Left `docs/LLM_VALIDATION_RUNBOOK.md` Step 3.11 intact because Step 3 chose Option A and REPL is now part of the supported surface again.
+
+**Problems Found:**
+
+- The stale-doc drift was broader than the original Step 5 bullets: once REPL became public, multiple release-facing docs still carried the old 64-command count. Fixing only `docs/READINESS_ASSESSMENT.md` would have left the launch plan, roadmap, runbook, and command reference internally inconsistent.
+
+**Final Verdict:**
+
+- [x] All 5 steps complete
+- [x] All check commands pass (build, typecheck, test, lint)
+- [x] All 3 blockers resolved and verified live
+- [x] Docs are consistent with actual product behavior
+- [x] Ready for 1.0 tag and release

--- a/validation/LLM_VALIDATION_RESULTS.md
+++ b/validation/LLM_VALIDATION_RESULTS.md
@@ -1,0 +1,52 @@
+# LLM Validation Results — 1.0 Gate
+
+**Date:** 2026-04-10
+**Agent:** GitHub Copilot (GPT-5.4)
+**Codebase:** 64 commands, 1009 tests
+
+## Summary
+
+Baseline checks passed cleanly: `npm run build`, `npx vitest run`, `npx tsc --noEmit`, and `npx eslint src/ tests/` all succeeded. Two release-affecting `run` defects and one package/doc issue were fixed inline during validation.
+
+| Category                   | Steps | Pass | Fail | Blocked |
+| -------------------------- | ----- | ---- | ---- | ------- |
+| Scenario re-runs (4 sites) | 4     | 3    | 0    | 1       |
+| New command validation     | 6     | 2    | 4    | 0       |
+| Error recovery             | 1     | 0    | 1    | 0       |
+| Export quality             | 1     | 0    | 1    | 0       |
+| Skill & package audit      | 2     | 1    | 1    | 0       |
+| **Total**                  | 14    | 6    | 7    | 1       |
+
+Partial steps are counted under `Fail` in the table because this roll-up format has no separate `Partial` column.
+
+## Blockers Found
+
+- Failed `open` calls can report stale page metadata and snapshot paths from the previously active session, which is misleading for the exact agent workflow this tool is shipping to support.
+- The packaged `.github/skills/cypress-cli/SKILL.md` is stale and inaccurate for the current CLI output and command surface, so agent discoverability currently teaches the wrong interface.
+- REPL mode is still treated as part of the product surface in validation/readiness docs, but the public CLI does not expose `repl`; 1.0 needs either a real public `repl` command or consistent docs that remove it from the supported surface.
+
+## Should-Fix Issues
+
+- `state-save` / `state-load` ergonomics drifted: `state-load` now requires a filename, but `state-save` does not print the default file path in human-readable output.
+- The storage and network portions of the runbook use targets that do not cleanly validate the intended behavior in Cypress (`https://example.com` reachability, JSON endpoint via `navigate`).
+- `cyrun` executes successfully but does not surface yielded values back to the caller, which makes it much less useful than `eval` or `run-code` for exploratory agent workflows.
+- Exported selector quality is still uneven on weakly instrumented pages; several flows replayed successfully, but long absolute selectors remain common outside data-attribute-rich sites.
+- SPA settling is sometimes laggy in the snapshot/output path, producing transient stale or near-empty snapshots until an explicit follow-up command is run.
+- CLI ergonomics around empty-string assertions are weak because `assert ... have.value ''` is parsed as if the expected value were missing.
+- Baseline validation still emitted runtime warnings (`tsconfig-paths` warnings and a `MaxListenersExceededWarning`) despite the readiness doc claiming those warnings were resolved.
+
+## Launch Plan Observations
+
+The launch plan's baseline counts are accurate, and the explicit package checklist directly caught a real release issue (`THIRD_PARTY_LICENSES` missing from the tarball before the inline fix). That level of specificity is useful and should stay.
+
+The plan currently understates the scope of the final confidence gate. In practice, the runbook is doing more than "test three sites": it is validating `export` together with `run`, error recovery semantics, agent-skill accuracy, and release packaging. Those should be reflected more explicitly in Phase 1 so the time estimate and exit criteria match reality.
+
+The current 1–2 day estimate for Phase 1 looks optimistic if live-site validation remains part of the gate, because external outages and weakly chosen validation targets can consume time without telling you much about the product. The runbook should explicitly allow substitute sites and should prefer targets that exercise the feature under test without avoidable network ambiguity.
+
+The plan should also elevate usability criteria, not just correctness criteria, for 1.0. Selector robustness, snapshot-settling behavior, and truthful error output all materially affect whether an LLM can stay oriented without human intervention.
+
+## Verdict
+
+**NOT READY for 1.0 release.**
+
+The codebase is close: the baseline is green, real end-to-end flows on TodoMVC, SauceDemo, and Conduit exported and replayed successfully, and two important `run` defects were fixed inline. But the remaining blockers are on the exact public surface being launched to agents and users: misleading failed-`open` output, stale packaged skill documentation, and unresolved REPL surface ambiguity mean the product/docs contract is still inconsistent enough that shipping 1.0 now would create avoidable confusion.

--- a/validation/VALIDATION_RESULTS_066.md
+++ b/validation/VALIDATION_RESULTS_066.md
@@ -1,0 +1,169 @@
+# Issue #66 — LLM Validation Results
+
+**Date**: 2026-04-04  
+**Test target**: https://example.cypress.io/commands/actions + /querying + /traversal  
+**Agent**: Claude (via cypress-cli direct CLI invocation)  
+**Branch**: main (c67bb10)
+
+---
+
+## Summary
+
+The tool is **usable for realistic LLM-driven test generation**. All major
+workflows succeeded end-to-end: open → snapshot → interact → assert → export.
+The previous blocking issues (#72 assertion chainers, #45 snapshot-to-file,
+#46 inline codegen, #49 fill command) are **all fixed**.
+
+Two new bugs were found, both related to `formatResult()` dropping data from
+daemon-local commands.
+
+---
+
+## Commands Tested
+
+| #   | Command                                            | Result         | Notes                                          |
+| --- | -------------------------------------------------- | -------------- | ---------------------------------------------- |
+| 1   | `open https://example.cypress.io/commands/actions` | ✅ Pass        | Full snapshot returned with file path          |
+| 2   | `snapshot`                                         | ✅ Pass        | All elements identifiable by role + name + ref |
+| 3   | `type e40 'hello@example.com'`                     | ✅ Pass        | Generated `cy.get('#email1').type(...)`        |
+| 4   | `assert e40 have.value 'hello@example.com'`        | ✅ Pass        | **Previously broken (#72), now fixed**         |
+| 5   | `focus e59`                                        | ✅ Pass        |                                                |
+| 6   | `type e75 'John Doe'`                              | ✅ Pass        |                                                |
+| 7   | `blur e75`                                         | ✅ Pass        |                                                |
+| 8   | `clear e91`                                        | ✅ Pass        |                                                |
+| 9   | `type e91 'Hello from cypress-cli'`                | ✅ Pass        |                                                |
+| 10  | `check e176`                                       | ✅ Pass        | Checkbox checked                               |
+| 11  | `assert e176 be.checked`                           | ✅ Pass        | **Previously unsupported, now works**          |
+| 12  | `uncheck e220`                                     | ✅ Pass        | Pre-checked checkbox unchecked                 |
+| 13  | `assert e220 not.be.checked`                       | ✅ Pass        | Negated assertion works                        |
+| 14  | `select e241 apples`                               | ✅ Pass        |                                                |
+| 15  | `assert e241 have.value fr-apples`                 | ✅ Pass        |                                                |
+| 16  | `type e107 'HALFOFF'`                              | ✅ Pass        |                                                |
+| 17  | `click e108` (Submit button)                       | ✅ Pass        |                                                |
+| 18  | `click e121` (Popover toggle)                      | ✅ Pass        |                                                |
+| 19  | `dblclick e145`                                    | ✅ Pass        |                                                |
+| 20  | `rightclick e160`                                  | ✅ Pass        |                                                |
+| 21  | `scrollto bottom`                                  | ✅ Pass        |                                                |
+| 22  | `asserturl include 'commands/actions'`             | ✅ Pass        |                                                |
+| 23  | `asserttitle include 'Kitchen Sink'`               | ✅ Pass        |                                                |
+| 24  | `history`                                          | ❌ Bug         | Returns "OK" — data lost                       |
+| 25  | `history --json`                                   | ✅ Data exists | JSON shows all 24 entries with correct state   |
+| 26  | `undo`                                             | ❌ Bug         | Returns "OK" — message lost                    |
+| 27  | `navigate .../querying`                            | ✅ Pass        |                                                |
+| 28  | `click e38` (on new page)                          | ✅ Pass        |                                                |
+| 29  | `asserturl eq '<full URL>'`                        | ✅ Pass        |                                                |
+| 30  | `navigate .../traversal`                           | ✅ Pass        |                                                |
+| 31  | `asserttitle eq 'Cypress.io: Kitchen Sink'`        | ✅ Pass        |                                                |
+| 32  | `export --file cypress/e2e/validation.cy.ts`       | ✅ Pass        | Valid .cy.ts file                              |
+| 33  | `export --file cypress/e2e/full-validation.cy.ts`  | ✅ Pass        | Multi-page export                              |
+| 34  | `stop`                                             | ✅ Pass        | Clean shutdown                                 |
+
+## Error Recovery Tests
+
+| #   | Scenario                                   | Result  | Notes                                                            |
+| --- | ------------------------------------------ | ------- | ---------------------------------------------------------------- |
+| E1  | `click e999` (nonexistent ref)             | ✅ Good | `Ref "e999" not found... Run snapshot to refresh`                |
+| E2  | `assert e40 have.value 'wrong-value'`      | ✅ Good | `Expected "wrong-value" but got "hello@example.com"`             |
+| E3  | `type 'not-a-ref' 'text'` (malformed ref)  | ✅ Good | Same clear error message                                         |
+| E4  | `check e38` (wrong element type after nav) | ✅ Good | `Cannot check <a> — cy.check() can only be called on checkboxes` |
+| E5  | `navigate not-a-url` (invalid URL)         | ✅ Good | Cypress error with path details                                  |
+| E6  | `assert e1 have.nonexistentprop 'x'`       | ✅ Good | `Unsupported chainer`                                            |
+| E7  | Session recovery after errors              | ✅ Good | All subsequent commands worked after error                       |
+
+---
+
+## Issues Found
+
+### Bug: `history` and `undo` output is lost in human-readable mode
+
+**Severity**: Friction (not blocking — `--json` workaround exists)
+
+Both `history` and `undo` put their response data in the `snapshot` field of
+`ResponseMessage`. The `formatResult()` function in `cli.ts` (line 253) strips
+the `snapshot` field before rendering key-value output. With no other fields
+remaining, it falls through to returning `"OK"`.
+
+**Impact**: An LLM using the CLI gets no feedback from `history` or `undo`. It
+cannot inspect the command log or confirm what was undone without using
+`--json` mode.
+
+**Root cause**: `handlers.ts` reuses the `snapshot` field for non-snapshot data.
+The CLI formatter assumes `snapshot` always contains YAML and strips it.
+
+**Fix**: Either:
+
+- Use a dedicated field (e.g., `entries` for history, `undoneAction` for undo)
+- Or add special handling in `formatResult()` for these commands
+
+### Polish: Fragile CSS selectors for elements without IDs
+
+Elements without IDs get long structural selectors:
+
+```
+cy.get('#actions > div > div:nth-of-type(26) > div > div:nth-of-type(1) > div:nth-of-type(1) > label > input')
+```
+
+This was noted in the previous validation and remains. Not blocking since the
+selectors work, but they break on any DOM restructuring.
+
+### Polish: `asserturl` syntax non-obvious
+
+First attempt was `asserturl '**/commands/actions'` which failed with a
+validation error. The correct syntax requires a chainer: `asserturl include
+'commands/actions'`. An LLM would likely need one failed attempt to learn
+this.
+
+### Observation: Stale refs after navigation
+
+After navigating from `/querying` to `/traversal`, ref `e38` (which was a
+button on the querying page) silently resolved to a different `<a>` element on
+the traversal page. Cypress gave a clear type-mismatch error, but there was no
+warning about using a stale ref.
+
+---
+
+## Comparison with Previous Validation
+
+| Previous Finding                                      | Current Status                                      |
+| ----------------------------------------------------- | --------------------------------------------------- |
+| `assert` can't check input values (#72)               | ✅ **Fixed**                                        |
+| Missing `be.visible`, `be.checked`, `have.attr` (#72) | ✅ **Fixed**                                        |
+| Fragile structural selectors                          | ⚠️ Still present                                    |
+| Snapshot-to-file (#45)                                | ✅ **Fixed** — snapshots written to `.cypress-cli/` |
+| Inline codegen (#46)                                  | ✅ **Fixed** — `# Ran Cypress code:` line shown     |
+| `fill` command (#49)                                  | ✅ **Implemented**                                  |
+
+---
+
+## Export Quality Assessment
+
+The exported test files are:
+
+- ✅ Valid TypeScript with `/// <reference types="cypress" />` header
+- ✅ Proper `describe`/`it` structure
+- ✅ Multi-page navigation handled with `cy.visit()` transitions
+- ✅ Failed commands correctly excluded from export
+- ✅ Assertions preserved (have.value, be.checked, include, eq)
+- ⚠️ Some selectors are fragile (nth-of-type chains)
+- ✅ IDs used when available (email1, password1, description, query-btn)
+
+---
+
+## Usability Assessment for LLMs
+
+| Criteria                | Rating       | Notes                                        |
+| ----------------------- | ------------ | -------------------------------------------- |
+| Snapshot readability    | ✅ Excellent | YAML with refs, roles, names, states         |
+| Ref stability           | ✅ Good      | Stable within a page; reset on navigation    |
+| Command discoverability | ✅ Good      | `--help`, clear arg validation errors        |
+| Error recovery          | ✅ Excellent | Clear errors + snapshot in all failure cases |
+| Interaction commands    | ✅ Complete  | type, click, check, select, scroll, etc.     |
+| Assertion commands      | ✅ Fixed     | All major chainers now supported             |
+| Export quality          | ✅ Good      | Valid, runnable Cypress code                 |
+| Token efficiency        | ✅ Fixed     | Snapshots written to files                   |
+| `history`/`undo` output | ❌ Bug       | Returns "OK" in human-readable mode          |
+| Selector quality        | ⚠️ Mixed     | Great with IDs, fragile without              |
+
+**Overall: Ready for LLM use in typical workflows.** The blocking issues from
+the first validation are all resolved. The remaining issues are friction/polish
+level.


### PR DESCRIPTION
## Summary

Resolves the three blockers identified during the 1.0 validation runbook and adds release documentation.

### Bug Fixes
- **Failed `open` stale output** — When reusing a session, a failed navigate no longer returns the previous page's URL/title/snapshot. Only the error is returned.
- **Daemon session timeout and error handling** — Hardened daemon handler error recovery and session timeout management.

### Features
- **REPL exposed as public command** — `cypress-cli repl` now starts an interactive session. Registered in commands.ts (core category), wired in cli.ts. Command count: 65 public / 69 registry entries.

### Documentation
- **SKILL.md rewrite** — Complete rewrite for current 65-command surface with correct output format, grouped tables, and run-code/cyrun distinctions.
- **Release docs** — Added LAUNCH_PLAN.md, BLOCKER_FIX_PLAN.md, NEXT_STEPS_PLAN.md, LLM_VALIDATION_RUNBOOK.md.
- **Stale reference cleanup** — Updated command counts (64→65), test counts, reclassified tsconfig-paths/MaxListenersExceededWarning as non-blocking noise.
- **playwright-cli skill references** — Added cross-tool comparison docs.
- **Validation artifacts** — LLM validation log with all blocker fix entries and results.

### Validation
- All 1012 tests passing (52 files)
- TypeScript strict mode clean
- ESLint clean
- Live CLI validation performed for all three blocker fixes